### PR TITLE
Changed license to show 'Sim' or 'Não' instead of '0' or '1'

### DIFF
--- a/laravel/app/Models/Driver.php
+++ b/laravel/app/Models/Driver.php
@@ -54,4 +54,9 @@ class Driver extends Model
     {
         return $this->user->status_code;
     }
+
+    public function getHeavyLicenseAttribute($value)
+    {
+        return $value ? 'Sim' : 'Não';
+    }
 }


### PR DESCRIPTION
Used Accessors to display heavy_license as 'Sim' ('Yes') or 'Não' ('No')