### PR TITLE
Orders, Mangers and Drivers Refactor

### DIFF
--- a/laravel/app/Http/Controllers/DriverController.php
+++ b/laravel/app/Http/Controllers/DriverController.php
@@ -11,6 +11,7 @@ use InvalidArgumentDException;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\DB;
 use App\Helpers\ErrorMessagesHelper;
+use App\Rules\DriverLicenseNumberValidation;
 use App\Rules\RoleUserTypeValidation;
 
 class DriverController extends Controller
@@ -35,7 +36,6 @@ class DriverController extends Controller
         return Inertia::render('Drivers/NewDriver', ['users' => $users]);
     }
 
-    //TODO: FRONT-END FOR LICENSE NUMBER
     public function createDriver(Request $request)
     {
         // Load custom error messages from helper
@@ -47,59 +47,33 @@ class DriverController extends Controller
                 'numeric',
                 new RoleUserTypeValidation(),
             ],
-            /*
-                Aveiro - AV.
-                Beja - BE.
-                Braga - BR.
-                Bragança - BG.
-                Castelo Branco - CB.
-                Coimbra - C.
-                Évora - E.
-                Faro - FA.
-                Guarda - GD.
-                Leiria - LE.
-                Lisboa - L.
-                Portalegre - PT.
-                Porto - P.
-                Santarém - SA.
-                Setúbal - SE.
-                Viana do Castelo - VC.
-                Vila Real - VR.
-                Viseu - VS.
-                Angra do Heroísmo - AN.
-                Horta - H.
-                Ponta Delgada - A.
-                Funchal - M.
-            */
-            'license_region_identifier' => ['required', 'min:1', 'max:2', Rule::in(['AV','BE','BR','BG','CB','C','E','FA','GD','LE','L','PT','P','SA','SE','VC','VR','VS','AN','H','A','M'])],
-            'license_middle_digits' => ['required', 'regex:/^[0-9]{6}$/'],
-            'license_last_digit' => ['required', 'regex:/^[0-9]{1}$/'],
+            'license_number' => [
+                'required', 
+                'regex:/^[A-Z]{1,2}-\d{6} \d$/',
+                new DriverLicenseNumberValidation(),
+            ],
             'heavy_license' => ['required', 'boolean'],
             'heavy_license_type' => ['required_if:heavy_license,1', Rule::in([null, 'Mercadorias', 'Passageiros'])], // Required only if heavy_vehicle is 1
         ], $customErrorMessages);
 
-        $incomingFields['license_region_identifier'] = strip_tags($incomingFields['license_region_identifier']);
-        $incomingFields['license_region_identifier'] = strip_tags($incomingFields['license_region_identifier']);
-        $incomingFields['license_region_identifier'] = strip_tags($incomingFields['license_region_identifier']);
+        $incomingFields['license_number'] = strip_tags($incomingFields['license_number']);
 
         if($incomingFields['heavy_license'] == '0') {
             $incomingFields['heavy_license_type'] = null;
         } 
-
-        $licenseNumber = $incomingFields['license_region_identifier'] . '-' . $incomingFields['license_middle_digits'] . ' ' .  $incomingFields['license_last_digit'];
 
         DB::beginTransaction();
         try {
             $user = User::findOrFail($incomingFields['user_id']);
 
             //TODO: SHOULD BE FRONT-END MESSAGE
-            if (DB::table('drivers')->where('license_number', $licenseNumber)->exists()) {
+            if (DB::table('drivers')->where('license_number', $incomingFields['license_number'])->exists()) {
                 throw new \InvalidArgumentException("Este número de carta já está associado a outro condutor");
             }
 
             $driver = Driver::create([
                 'user_id' => $incomingFields['user_id'],
-                'license_number' => $licenseNumber,
+                'license_number' => $incomingFields['license_number'],
                 'heavy_license' => $incomingFields['heavy_license'],
                 'heavy_license_type' => $incomingFields['heavy_license_type'],
             ]);
@@ -129,7 +103,6 @@ class DriverController extends Controller
         ]);
     }
 
-    //TODO: FRONT-END FOR LICENSE NUMBER
     public function editDriver(Driver $driver, Request $request)
     {
 
@@ -138,33 +111,11 @@ class DriverController extends Controller
 
         $incomingFields = $request->validate([
             'user_id' => 'required',
-            /*
-                Aveiro - AV.
-                Beja - BE.
-                Braga - BR.
-                Bragança - BG.
-                Castelo Branco - CB.
-                Coimbra - C.
-                Évora - E.
-                Faro - FA.
-                Guarda - GD.
-                Leiria - LE.
-                Lisboa - L.
-                Portalegre - PT.
-                Porto - P.
-                Santarém - SA.
-                Setúbal - SE.
-                Viana do Castelo - VC.
-                Vila Real - VR.
-                Viseu - VS.
-                Angra do Heroísmo - AN.
-                Horta - H.
-                Ponta Delgada - A.
-                Funchal - M.
-            */
-            'license_region_identifier' => ['required', 'min:1', 'max:2', Rule::in(['AV','BE','BR','BG','CB','C','E','FA','GD','LE','L','PT','P','SA','SE','VC','VR','VS','AN','H','A','M'])],
-            'license_middle_digits' => ['required', 'regex:/^[0-9]{6}$/'],
-            'license_last_digit' => ['required', 'regex:/^[0-9]{1}$/'],
+            'license_number' => [
+                'required', 
+                'regex:/^[A-Z]{1,2}-\d{6} \d$/',
+                new DriverLicenseNumberValidation(),
+            ],
             'heavy_license' => ['required', 'boolean'],
             'heavy_license_type' => ['required_if:heavy_license,1', Rule::in([null, 'Mercadorias', 'Passageiros'])], // Required only if heavy_vehicle is 1
             'name' => ['required', 'string', 'max:255'],
@@ -175,9 +126,7 @@ class DriverController extends Controller
 
         $incomingFields['name'] = strip_tags($incomingFields['name']);
         $incomingFields['email'] = strip_tags($incomingFields['email']);
-        $incomingFields['license_region_identifier'] = strip_tags($incomingFields['license_region_identifier']);
-
-        $licenseNumber = $incomingFields['license_region_identifier'] . '-' . $incomingFields['license_middle_digits'] . ' ' .  $incomingFields['license_last_digit'];
+        $incomingFields['license_number'] = strip_tags($incomingFields['license_number']);
 
         if($incomingFields['heavy_license'] == '0') {
             $incomingFields['heavy_license_type'] = null;
@@ -186,12 +135,12 @@ class DriverController extends Controller
         DB::beginTransaction();
         try {
             //TODO: SHOULD BE FRONT-END MESSAGE
-            if (DB::table('drivers')->where('license_number', $licenseNumber)->whereNot('user_id', $driver->user_id)->exists()) {
+            if (DB::table('drivers')->where('license_number', $incomingFields['license_number'])->whereNot('user_id', $driver->user_id)->exists()) {
                 throw new \InvalidArgumentException("Este número de carta já está associado a outro condutor");
             }
 
             $driver->update([
-                'license_number' => $licenseNumber,
+                'license_number' => $incomingFields['license_number'],
                 'heavy_license' => $incomingFields['heavy_license'],
                 'heavy_license_type' => $incomingFields['heavy_license_type'],
             ]);

--- a/laravel/app/Http/Controllers/ManagerController.php
+++ b/laravel/app/Http/Controllers/ManagerController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\User;
 use Inertia\Inertia;
+use App\Models\Order;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use App\Helpers\ErrorMessagesHelper;
@@ -116,6 +117,18 @@ class ManagerController extends Controller
             dd($e);
             return redirect()->route('managers.index')->with('error', 'Houve um problema ao retirar o utilizador com id ' . $id . ' da lista de gestores. Tente novamente.');
         }
+    }
+
+    public function showManagerApprovedOrders(User $user) {
+        $orders = Order::where('manager_id', $user->id)->get();
+        
+        return Inertia::render('Managers/showApprovedOrders', [
+            'flash' => [
+                'message' => session('message'),
+                'error' => session('error'),
+            ],
+            'orders' => $orders,
+        ]);
     }
 
     //TODO: MANAGERS FRONTEND TABLE SHOULD HAVE LINK FOR ALL APPROVED ORDERS BY HIM

--- a/laravel/app/Http/Controllers/OrderController.php
+++ b/laravel/app/Http/Controllers/OrderController.php
@@ -309,4 +309,31 @@ class OrderController extends Controller
             return redirect()->route('orders.index')->with('error', 'Houve um problema ao aprovar o pedido com id ' . $order->id . '. Tente novamente.');
         }
     }
+
+    public function removeOrderApproval(Order $order, Request $request) 
+    {
+        //$managerId = Auth::id(); --------> to use on calling this page to get logged in user id
+
+        $request->validate([
+            'manager_id' => [
+                'required', 
+                'exists:users,id', 
+                new ManagerUserTypeValidation(),
+            ]
+        ]);
+
+        try {
+            $order->update([
+                'manager_id' => null,
+                'approved_date' => null,
+                'status' => 'Por aprovar'
+            ]);
+
+            return redirect()->route('orders.index')->with('message', 'Aprovação removida do pedido com id ' . $order->id . ' com sucesso!');
+
+        } catch (\Exception $e) {
+            dd($e);
+            return redirect()->route('orders.index')->with('error', 'Houve um problema ao remover a aprovação o pedido com id ' . $order->id . '. Tente novamente.');
+        }
+    }
 }

--- a/laravel/app/Http/Controllers/OrderController.php
+++ b/laravel/app/Http/Controllers/OrderController.php
@@ -154,7 +154,7 @@ class OrderController extends Controller
         $vehicles = Vehicle::all();
         $technicians = User::where('user_type', 'Técnico')->get();
         $managers = User::where('user_type', 'Gestor')->get();
-        $places = Place::all();                     //TODO: TO BE CHANGED
+        $places = Place::all();
         $kids = Kid::with('places')->get();
         $otherPlaces = Place::whereNot('place_type', 'Residência');
         $routes = OrderRoute::all();

--- a/laravel/app/Http/Controllers/UserController.php
+++ b/laravel/app/Http/Controllers/UserController.php
@@ -47,12 +47,14 @@ class UserController extends Controller
         $incomingFields = $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email', 'lowercase'],
-            'phone' => ['required', 'numeric', 'digits_between:9,15', 'unique:users,phone'],
+            'phone' => ['nullable', 'numeric', 'digits_between:9,15', 'unique:users,phone'],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ], $customErrorMessages);
 
         $incomingFields['name'] = strip_tags($incomingFields['name']);
         $incomingFields['email'] = strip_tags($incomingFields['email']);
+
+        $incomingFields['phone'] = $incomingFields['phone'] ?? null;
 
         try {
             $user = User::create([
@@ -83,7 +85,6 @@ class UserController extends Controller
         ]);
     }
 
-    //TODO: should phone be unique for each user???
     public function editUser(User $user, Request $request)
     {
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
@@ -91,12 +92,14 @@ class UserController extends Controller
         $incomingFields = $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'email', 'max:255', Rule::unique('users', 'email')->ignore($user->id), 'lowercase'], // Ignore current user's email,
-            'phone' => ['required', 'numeric', 'digits_between:9,15', Rule::unique('users', 'phone')->ignore($user->id)],
+            'phone' => ['nullable', 'numeric', 'digits_between:9,15', Rule::unique('users', 'phone')->ignore($user->id)],
             'status' => ['required', Rule::in(['Disponível', 'Indisponível', 'Em Serviço', 'Escondido'])],
         ], $customErrorMessages);
 
         $incomingFields['name'] = strip_tags($incomingFields['name']);
         $incomingFields['email'] = strip_tags($incomingFields['email']);
+
+        $incomingFields['phone'] = $incomingFields['phone'] ?? null;
 
         try {
             $user->update($incomingFields);

--- a/laravel/app/Models/Kid.php
+++ b/laravel/app/Models/Kid.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
-//TODO: SHOULD KID HAVE MULTIPLE PHONE NUMBERS AND EMAILS (NEW TABLES) -> YES!!!
+//TODO: SHOULD KID BE ALLOWED TO HAVE MULTIPLE PHONE NUMBERS AND EMAILS (NEW TABLES)???
 class Kid extends Model
 {
     use HasFactory;

--- a/laravel/app/Models/Order.php
+++ b/laravel/app/Models/Order.php
@@ -17,6 +17,7 @@ class Order extends Model
         'expected_end_date',
         'trajectory',
         'order_type',
+        'status',
 
         'vehicle_id',
         'driver_id',

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -11,7 +11,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
-//TODO: SHOULD USER BE ALLOWED TO HAVE MULTIPLE PHONE NUMBERS AND EMAILS (NEW TABLES)
 class User extends Authenticatable
 {
     use HasFactory, Notifiable;

--- a/laravel/app/Rules/DriverLicenseNumberValidation.php
+++ b/laravel/app/Rules/DriverLicenseNumberValidation.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class DriverLicenseNumberValidation implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+         $prefix = explode('-', $value)[0];
+        
+         $allowedPrefixes = ['AV','BE','BR','BG','CB','C','E','FA','GD','LE','L','PT','P','SA','SE','VC','VR','VS','AN','H','A','M'];
+
+         if (!in_array($prefix, $allowedPrefixes)) {
+             $fail('Letras iniciais inseridas são inválidas. Só são permitidos estes conjuntos, correspondes à região portuguesa que emitiu a carta:
+                    AV (Aveiro), BE (Beja), BR (Braga), BG (Bragança), CB (Castelo Branco), C (Coimbra), E (Évora), FA (Faro), GD (Guarda), LE (Leiria), L (Lisboa), PT (Portalegre), 
+                    P (Porto), SA (Santarém), SE (Setúbal), VC (Viana do Castelo), VR (Vila Real), VS (Viseu), AN (Angra do Heroísmo), H (Horta), A (Ponta Delgada), M (Funchal)',
+                );
+         }
+    }
+}

--- a/laravel/app/Rules/ManagerUserTypeValidation.php
+++ b/laravel/app/Rules/ManagerUserTypeValidation.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use App\Models\User;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class ManagerUserTypeValidation implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        // Check if the manager_id belongs to a user with 'Gestor' type
+        $user = User::find($value);
+        if (!$user || $user->user_type !== 'Gestor') {
+            $fail('O utilizador com id ' . $value . ' selecionado não está autorizado a aprovar pedidos');
+        }
+    }
+}

--- a/laravel/database/factories/OrderFactory.php
+++ b/laravel/database/factories/OrderFactory.php
@@ -44,9 +44,26 @@ class OrderFactory extends Factory
 
         $route = $hasRoute? OrderRouteFactory::new()->create() : null;
 
+        $beginDate = fake()->dateTimeBetween('2024-01-01', '2025-12-31');
+        $endDate = (clone $beginDate)->modify('+1 day');
+
+        // Future Order
+        if ($beginDate > now()) {
+            $status = Arr::random(['Por aprovar', 'Cancelado/Não aprovado', 'Aprovado']);
+
+        // Past Order
+        } else if (now() > $endDate) {
+            $status = Arr::random(['Cancelado/Não aprovado', 'Finalizado', 'Interrompido']);
+
+        // Current Order
+        } else {
+            $status = 'Em curso';
+        }
+
         return [
-            'expected_begin_date' => fake()->dateTimeBetween('2024-01-01', '2025-12-31'),
-            'expected_end_date' => fake()->dateTimeBetween('2024-01-01', '2025-12-31'),
+            'expected_begin_date' => $beginDate,
+            'expected_end_date' => $endDate,
+            'status' => $status,
             'trajectory' => json_encode($trajectory),
             'order_type' => Arr::random(['Transporte de Pessoal','Transporte de Mercadorias','Transporte de Crianças', 'Outros']),
 

--- a/laravel/database/migrations/2024_08_13_095919_add_fields_to_users_table.php
+++ b/laravel/database/migrations/2024_08_13_095919_add_fields_to_users_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->string('phone')->default('0');              //TODO: Take off defaults
+            $table->string('phone')->nullable()->unique();
             $table->enum('user_type',['Nenhum','Condutor','Gestor','Técnico','Administrador'])->default('Nenhum');
             $table->enum('status', ['Disponível', 'Indisponível', 'Em Serviço', 'Escondido']);
         });

--- a/laravel/database/migrations/2024_09_27_095051_create_orders_table.php
+++ b/laravel/database/migrations/2024_09_27_095051_create_orders_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        //TODO: ADD MORE FOREIGN AS MORE TABLES ARE ADDED (ORDER_STATUS)
+        //TODO: ADD MORE FOREIGN AS MORE TABLES ARE ADDED (STATUS)
         //TODO: IF A USER IS DELETED WHAT HAPPENS TO A ORDER -> STATUS FOR EVERY TABLE SHOULD HOLD A DELETED OPTION INSTEAD OF REMOVING FROM DB
         Schema::create('orders', function (Blueprint $table) {
             $table->id();
@@ -22,6 +22,7 @@ return new class extends Migration
             $table->dateTime('expected_end_date')->nullable();
             $table->dateTime('approved_date')->nullable();
             $table->enum('order_type', ['Transporte de Pessoal','Transporte de Mercadorias','Transporte de Crianças', 'Outros']);
+            $table->enum('status', ['Por aprovar', 'Cancelado/Não aprovado', 'Aprovado', 'Em curso', 'Finalizado', 'Interrompido']);
 
             $table->unsignedBigInteger('vehicle_id')->nullable();
             $table->foreign('vehicle_id')->references('id')->on('vehicles')->onDelete('set null');

--- a/laravel/database/migrations/2024_09_27_095150_create_order_stops_table.php
+++ b/laravel/database/migrations/2024_09_27_095150_create_order_stops_table.php
@@ -11,8 +11,8 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('order_stops', function (Blueprint $table) {             //TODO: ADD MORE FOREIGN AS MORE TABLES ARE ADDED (ORDER_STATUS)
-            $table->id();                                                       //TODO: CHECK CASCADES ON EVERY TABLE
+        Schema::create('order_stops', function (Blueprint $table) {
+            $table->id();
             $table->timestamps();
             $table->dateTime('planned_arrival_date')->nullable();
             $table->dateTime('actual_arrival_date')->nullable();

--- a/laravel/resources/js/Layouts/AuthenticatedLayout.jsx
+++ b/laravel/resources/js/Layouts/AuthenticatedLayout.jsx
@@ -108,7 +108,7 @@ export default function Authenticated({ user, header, children }) {
 
                                             <Dropdown.Content>
                                                 <Dropdown.Link  href={route('orders.index')} active={route().current('orders.index')}>Todos os Pedidos</Dropdown.Link>
-                                                <Dropdown.Link  href={route('orders.create')} active={route().current('orders.create')}>Criar Pedido</Dropdown.Link>
+                                                <Dropdown.Link  href={route('orders.showCreate')} active={route().current('orders.showCreate')}>Criar Pedido</Dropdown.Link>
                                             </Dropdown.Content>
                                         </Dropdown>
                                     </div>

--- a/laravel/resources/js/Pages/Drivers/AllDrivers.jsx
+++ b/laravel/resources/js/Pages/Drivers/AllDrivers.jsx
@@ -47,7 +47,7 @@ export default function AllDrivers( {auth, drivers, flash} ) {
             <div className="py-12 px-6">
                 <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
 
-                    <Button href={route('drivers.create')}>
+                    <Button href={route('drivers.showCreate')}>
                         <AddIcon />
                         <a  className="font-medium text-sky-600 dark:text-sky-500 hover:underline">
                             Novo Condutor

--- a/laravel/resources/js/Pages/Kids/AllKids.jsx
+++ b/laravel/resources/js/Pages/Kids/AllKids.jsx
@@ -58,7 +58,7 @@ export default function AllKids( {auth, kids, flash} ) {
             <div className="py-12 px-6">
                 <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
 
-                    <Button href={route('kids.create')}>
+                    <Button href={route('kids.showCreate')}>
                         <AddIcon />
                         <a className="font-medium text-sky-600 dark:text-sky-500 hover:underline">
                             Nova Criança

--- a/laravel/resources/js/Pages/Managers/AllManagers.jsx
+++ b/laravel/resources/js/Pages/Managers/AllManagers.jsx
@@ -50,7 +50,7 @@ export default function AllManagers({ auth, managers, flash }) {
         
             <div className="py-12 px-6">
                 <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                    <Button href={route('managers.create')} className="font-medium text-blue-600 dark:text-blue-500 hover:underline">
+                    <Button href={route('managers.showCreate')} className="font-medium text-blue-600 dark:text-blue-500 hover:underline">
                         <AddIcon />
                         <a className="font-medium text-sky-600 dark:text-sky-500 hover:underline">
                             Novo Gestor

--- a/laravel/resources/js/Pages/Places/AllPlaces.jsx
+++ b/laravel/resources/js/Pages/Places/AllPlaces.jsx
@@ -52,7 +52,7 @@ export default function AllPlaces( {auth, places, flash} ) {
             <div className="py-12 px-6">
                 <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
 
-                    <Button href={route('places.create')}>
+                    <Button href={route('places.showCreate')}>
                         <AddIcon />
                         <a className="font-medium text-sky-600 dark:text-sky-500 hover:underline">
                             Nova Morada

--- a/laravel/resources/js/Pages/Technicians/AllTechnicians.jsx
+++ b/laravel/resources/js/Pages/Technicians/AllTechnicians.jsx
@@ -48,7 +48,7 @@ export default function AllTechnicians({ auth, technicians, flash }) {
         
             <div className="py-12 px-6">
                 <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                    <Button href={route('technicians.create')} className="font-medium text-blue-600 dark:text-blue-500 hover:underline">
+                    <Button href={route('technicians.showCreate')} className="font-medium text-blue-600 dark:text-blue-500 hover:underline">
                         <AddIcon />
                         <a className="font-medium text-sky-600 dark:text-sky-500 hover:underline">
                             Novo Técnico

--- a/laravel/resources/js/Pages/Users/AllUsers.jsx
+++ b/laravel/resources/js/Pages/Users/AllUsers.jsx
@@ -43,7 +43,7 @@ export default function AllDrivers( {auth, users, flash} ) {
         
             <div className="py-12 px-6">
                 <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                    <Button href={route('users.create')} className="font-medium text-blue-600 dark:text-blue-500 hover:underline">
+                    <Button href={route('users.showCreate')} className="font-medium text-blue-600 dark:text-blue-500 hover:underline">
                         <AddIcon />
                         <a className="font-medium text-sky-600 dark:text-sky-500 hover:underline">
                             Novo Utilizador

--- a/laravel/resources/js/Pages/Vehicles/AllVehicles.jsx
+++ b/laravel/resources/js/Pages/Vehicles/AllVehicles.jsx
@@ -69,7 +69,7 @@ export default function AllVehicles( {auth, vehicles, flash}) {
 
             <div className="py-12 px-6">
                 <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                    <Button href={route('vehicles.create')}>
+                    <Button href={route('vehicles.showCreate')}>
                         <AddIcon />
                         <a className="font-medium text-sky-600 dark:text-sky-500 hover:underline">
                             Novo Veículo

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -37,7 +37,7 @@ Route::middleware('auth')->group(function () {
 
     //DRIVERS
     Route::get('/drivers', [DriverController::class, 'index'])->name('drivers.index');                              //GET all page
-    Route::get('/drivers/create', [DriverController::class, 'showCreateDriverForm'])->name('drivers.create');       //GET creation page
+    Route::get('/drivers/create', [DriverController::class, 'showCreateDriverForm'])->name('drivers.showCreate');       //GET creation page
     Route::post('/drivers/create', [DriverController::class, 'createDriver'])->name('drivers.create');              //CREATE action
     Route::get('/drivers/edit/{driver}', [DriverController::class, 'showEditDriverForm'])->name('drivers.showEdit');    //GET edit page
     Route::put('/drivers/edit/{driver}', [DriverController::class, 'editDriver'])->name('drivers.edit');            //EDIT action
@@ -53,7 +53,7 @@ Route::middleware('auth')->group(function () {
     
     //MANAGERS (USER MODEL WITH Gestor USER_TYPE)
     Route::get('/managers', [ManagerController::class, 'index'])->name('managers.index');
-    Route::get('/managers/create', [ManagerController::class, 'showCreateManagerForm'])->name('managers.create');
+    Route::get('/managers/create', [ManagerController::class, 'showCreateManagerForm'])->name('managers.showCreate');
     Route::post('/managers/create', [ManagerController::class, 'createManager'])->name('managers.create');
     Route::get('/managers/edit/{user}', [ManagerController::class, 'showEditManagerForm'])->name('managers.showEdit');
     Route::put('/managers/edit/{user}', [ManagerController::class, 'editManager'])->name('managers.edit');
@@ -84,7 +84,7 @@ Route::middleware('auth')->group(function () {
     
     //PLACES
     Route::get('/places', [PlaceController::class, 'index'])->name('places.index');
-    Route::get('/places/create', [PlaceController::class, 'showCreatePlaceForm'])->name('places.create');
+    Route::get('/places/create', [PlaceController::class, 'showCreatePlaceForm'])->name('places.showCreate');
     Route::post('/places/create', [PlaceController::class, 'createPlace'])->name('places.create');
     Route::get('/places/edit/{place}', [PlaceController::class, 'showEditPlaceForm'])->name('places.showEdit');
     Route::put('/places/edit/{place}', [PlaceController::class, 'editPlace'])->name('places.edit');
@@ -97,7 +97,7 @@ Route::middleware('auth')->group(function () {
 
     //USERS
     Route::get('/users', [UserController::class, 'index'])->name('users.index');
-    Route::get('/users/create', [UserController::class, 'showCreateUserForm'])->name('users.create');
+    Route::get('/users/create', [UserController::class, 'showCreateUserForm'])->name('users.showCreate');
     Route::post('/users/create', [UserController::class, 'createUser'])->name('users.create');
     Route::get('/users/edit/{user}', [UserController::class, 'showEditUserForm'])->name('users.showEdit');
     Route::put('/users/edit/{user}', [UserController::class, 'editUser'])->name('users.edit');
@@ -105,7 +105,7 @@ Route::middleware('auth')->group(function () {
 
     //TECHNICIANS (USER MODEL WITH Técnico USER_TYPE)
     Route::get('/technicians', [TechnicianController::class, 'index'])->name('technicians.index');
-    Route::get('/technicians/create', [TechnicianController::class, 'showCreateTechnicianForm'])->name('technicians.create');
+    Route::get('/technicians/create', [TechnicianController::class, 'showCreateTechnicianForm'])->name('technicians.showCreate');
     Route::post('/technicians/create', [TechnicianController::class, 'createTechnician'])->name('technicians.create');
     Route::get('/technicians/edit/{user}', [TechnicianController::class, 'showEditTechnicianForm'])->name('technicians.showEdit');
     Route::put('/technicians/edit/{user}', [TechnicianController::class, 'editTechnician'])->name('technicians.edit');
@@ -113,7 +113,7 @@ Route::middleware('auth')->group(function () {
 
     //VEHICLES
     Route::get('/vehicles', [VehicleController::class, 'index'])->name('vehicles.index');
-    Route::get('/vehicles/create', [VehicleController::class, 'showCreateVehicleForm'])->name('vehicles.create');
+    Route::get('/vehicles/create', [VehicleController::class, 'showCreateVehicleForm'])->name('vehicles.showCreate');
     Route::post('/vehicles/create', [VehicleController::class, 'createVehicle'])->name('vehicles.create');
     Route::get('/vehicles/edit/{vehicle}', [VehicleController::class, 'showEditVehicleForm'])->name('vehicles.showEdit');
     Route::put('/vehicles/edit/{vehicle}', [VehicleController::class, 'editVehicle'])->name('vehicles.edit');

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -58,6 +58,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/managers/edit/{user}', [ManagerController::class, 'showEditManagerForm'])->name('managers.showEdit');
     Route::put('/managers/edit/{user}', [ManagerController::class, 'editManager'])->name('managers.edit');
     Route::delete('/managers/delete/{user}', [ManagerController::class, 'deleteManager'])->name('managers.delete');
+    Route::get('/managers/showApproved/{user}', [ManagerController::class, 'showManagerApprovedOrders'])->name('managers.showApproved'); 
 
     //ORDERS
     Route::get('/orders', [OrderController::class, 'index'])->name('orders.index');
@@ -67,6 +68,7 @@ Route::middleware('auth')->group(function () {
     Route::put('/orders/edit/{order}', [OrderController::class, 'editOrder'])->name('orders.edit');
     Route::delete('/orders/delete/{order}', [OrderController::class, 'deleteOrder'])->name('orders.delete');
     Route::put('/orders/approve/{order}',  [OrderController::class, 'approveOrder'])->name('orders.approve');
+    Route::put('/orders/removeApproval/{order}',  [OrderController::class, 'removeOrderApproval'])->name('orders.removeApproval');
 
     //ORDER ROUTES
     Route::get('/orderRoutes', [OrderRouteController::class, 'index'])->name('orderRoutes.index');

--- a/laravel/tests/Feature/ManagerTest.php
+++ b/laravel/tests/Feature/ManagerTest.php
@@ -45,6 +45,17 @@ class ManagerTest extends TestCase
 
         $response = $this
             ->actingAs($this->user)
+            ->get("/managers/showApproved/{$manager->id}");
+
+        $response->assertOk();
+    }
+
+    public function test_manager_approved_orders_page_is_displayed(): void
+    {
+        $manager = ManagerFactory::new()->create();
+
+        $response = $this
+            ->actingAs($this->user)
             ->get("/managers/edit/{$manager->id}");
 
         $response->assertOk();


### PR DESCRIPTION
Changed driver license number back-end validation to a single field.

Users phone field is now nullable.

Fixed routes show form creation names.

Added status attribute to the orders table (enum).

Added back-end function to remove approval of an order and implemented necessary tests.

Also, added back-end function to show a specific manager approved orders.