### PR TITLE
Notifications

### DIFF
--- a/laravel/app/Http/Controllers/NotificationController.php
+++ b/laravel/app/Http/Controllers/NotificationController.php
@@ -39,7 +39,7 @@ class NotificationController extends Controller
                 'is_read' => true,
             ]);
 
-            return redirect()->route('notifications.index')->with('message', 'Notificação com id ' . $notification->id . ' marcada como lida com sucesso!');
+            return response()->json(['message' => 'Notificação marcada como lida com sucesso!'], 200);
 
         } catch (\InvalidArgumentException $e) {
             return redirect()->back()->with('error', $e->getMessage());
@@ -49,6 +49,7 @@ class NotificationController extends Controller
             return redirect()->route('notifications.index')->with('error', 'Houve um problema ao marcar a notificação com id ' . $notification->id . ' como lida. Tente novamente.');
         }
     }
+    
 
     public function deleteNotification($id)
     {

--- a/laravel/app/Http/Controllers/NotificationController.php
+++ b/laravel/app/Http/Controllers/NotificationController.php
@@ -63,4 +63,10 @@ class NotificationController extends Controller
             return redirect()->route('notifications.index')->with('error', 'Houve um problema ao apagar a notificação com id ' . $notification->id . '. Tente novamente.');
         }
     }
+
+    public function getUnreadCount() {
+        $unreadCount = Auth::user()->notifications->where('is_read', '0')->count();
+
+        return response()->json(['unread_count' => $unreadCount]);
+    }
 }

--- a/laravel/app/Http/Controllers/OrderController.php
+++ b/laravel/app/Http/Controllers/OrderController.php
@@ -381,7 +381,7 @@ class OrderController extends Controller
     {
         $order->load(['occurrences', 'vehicle', 'driver']);
 
-        // Format the fields for each report entry
+        // Format the fields for each entry
         $order->occurrences->each(function ($occurrence) {
             $occurrence->created_at = \Carbon\Carbon::parse($occurrence->created_at)->format('d-m-Y');
             $occurrence->updated_at = \Carbon\Carbon::parse($occurrence->updated_at)->format('d-m-Y');

--- a/laravel/app/Http/Controllers/OrderController.php
+++ b/laravel/app/Http/Controllers/OrderController.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\DB;
 use App\Rules\KidVehicleValidation;
 use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
+use App\Notifications\OrderRequiresApprovalNotification;
 use App\Rules\ManagerUserTypeValidation;
 use App\Rules\OrderDriverLicenseValidation;
 use App\Rules\TechnicianUserTypeValidation;
@@ -168,6 +169,13 @@ class OrderController extends Controller
 
             DB::commit();
 
+            // Notify managers that order requires approval
+            foreach (User::where('user_type', 'Gestor')->get() as $user) {
+                $user->notify(new OrderRequiresApprovalNotification($order));
+            }
+
+            //TODO: Notify users involved of new order
+
             return redirect()->route('orders.index')->with('message', 'Pedido com id ' . $order->id . ' criado com sucesso!');
 
         } catch (\Exception $e) {
@@ -269,7 +277,7 @@ class OrderController extends Controller
                 'driver_id' => $incomingFields['driver_id'],
                 'technician_id' => $incomingFields['technician_id'],
                 'order_route_id' => $incomingFields['order_route_id'],
-                'status' => 'Por aprovar'
+                //TODO: IF AN ORDER IS EDITED, SHOULD IT NEED REAPPROVAL
             ]);
 
             //TODO: OPTIMIZE THIS -> SOME WAY OF DELETING ONLY THE NEEDED WHILE UPDATING THE EXISTING AND CREATING NEW ONES

--- a/laravel/app/Http/Controllers/OrderController.php
+++ b/laravel/app/Http/Controllers/OrderController.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\DB;
 use App\Rules\KidVehicleValidation;
 use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
+use App\Notifications\OrderCreationNotification;
 use App\Notifications\OrderRequiresApprovalNotification;
 use App\Rules\ManagerUserTypeValidation;
 use App\Rules\OrderDriverLicenseValidation;
@@ -174,7 +175,9 @@ class OrderController extends Controller
                 $user->notify(new OrderRequiresApprovalNotification($order));
             }
 
-            //TODO: Notify users involved of new order
+            // Notify users involved of new order
+            User::find($incomingFields['driver_id'])->notify(new OrderCreationNotification($order));
+            User::find($incomingFields['technician_id'])->notify(new OrderCreationNotification($order));
 
             return redirect()->route('orders.index')->with('message', 'Pedido com id ' . $order->id . ' criado com sucesso!');
 

--- a/laravel/app/Jobs/SendUnfilledKilometrageReportEntryNotification.php
+++ b/laravel/app/Jobs/SendUnfilledKilometrageReportEntryNotification.php
@@ -32,6 +32,7 @@ class SendUnfilledKilometrageReportEntryNotification implements ShouldQueue
         $previousMonthFirstDay = now()->subMonth()->startOfMonth();
         $previousMonthLastDay = now()->subMonth()->endOfMonth();
 
+        //TODO: IF THERE IS NO ORDER WITH THE VEHICLE, SHOULD THE ENTRY BE FILLED AT ALL?
         // Fetch vehicles and their kilometrage reports from the previous month
         $vehicles = Vehicle::with(['kilometrageReports' => function ($query) use ($previousMonthFirstDay, $previousMonthLastDay) {
             $query->where('date', '>=', $previousMonthFirstDay)

--- a/laravel/app/Notifications/Channels/CustomDbChannel.php
+++ b/laravel/app/Notifications/Channels/CustomDbChannel.php
@@ -5,7 +5,6 @@ namespace App\Notifications\Channels;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Auth;
 
-//TODO: CREATE MORE NOTIFICATION TYPES
 class CustomDbChannel
 {
   	public function send($notifiable, Notification $notification)

--- a/laravel/app/Notifications/OrderCreationNotification.php
+++ b/laravel/app/Notifications/OrderCreationNotification.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use App\Notifications\Channels\CustomDbChannel;
 use Illuminate\Notifications\Messages\MailMessage;
 
-class OrderRequiresApprovalNotification extends Notification
+class OrderCreationNotification extends Notification
 {
     use Queueable;
 
@@ -30,7 +30,7 @@ class OrderRequiresApprovalNotification extends Notification
      */
     public function via(object $notifiable): array
     {
-        return [CustomDbChannel::class];                //can include 'mail' after mail system is ready and show pages are built
+        return [CustomDbChannel::class];
     }
 
     /**
@@ -41,9 +41,9 @@ class OrderRequiresApprovalNotification extends Notification
         $expected_begin_date = \Carbon\Carbon::parse($this->order->expected_begin_date)->format('d-m-Y H:i');
 
         return (new MailMessage)
-                    ->line('Pedido necessita de aprovação.')
-                    ->action('Ver pedido em', route('orders.edit', ['order' => $this->order->id]))
-                    ->line('O pedido com id ' . $this->order->id . ' com data de início marcada para ' . $expected_begin_date . ', necessita de aprovação.');
+            ->line('Novo pedido.')
+            ->action('Ver pedido em', route('orders.edit', ['order' => $this->order->id]))
+            ->line('Foi criado um novo pedido com id ' . $this->order->id . ' com data de início marcada para ' . $expected_begin_date . 'em que estará envolvido.');
     }
 
     /**
@@ -60,9 +60,13 @@ class OrderRequiresApprovalNotification extends Notification
             'related_entity_type' => Order::class,
             'related_entity_id' => $this->order->id,
             'type' => 'Pedido',
-            'title' => 'Aprovação de Pedido',
-            'message' => 'O pedido com id ' . $this->order->id . ' com data de início marcada para ' . $expected_begin_date . ', necessita de aprovação.',
+            'title' => 'Novo Pedido',
+            'message' => 'Foi criado um novo pedido com id ' . $this->order->id . ' com data de início marcada para ' . $expected_begin_date . 'em que estará envolvido.',
             'is_read' => false,
         ];
+    }
+
+    public function getOrder() {
+        return $this->order;
     }
 }

--- a/laravel/app/Notifications/OrderOccurrenceNotification.php
+++ b/laravel/app/Notifications/OrderOccurrenceNotification.php
@@ -63,7 +63,7 @@ class OrderOccurrenceNotification extends Notification
             'user_id' => $notifiable->id,
             'related_entity_type' => Order::class,
             'related_entity_id' => $this->order->id,
-            'type' => 'Pedido',
+            'type' => 'Ocorrência',
             'title' => 'Nova ocorrência',
             'message' => 'Uma nova ocorrênica com id ' . $this->occurrence->id . ' do pedido ' . $this->order->id . ' foi reportada no dia ' . $date . '.',
             'is_read' => false,

--- a/laravel/app/Notifications/OrderRequiresApprovalNotification.php
+++ b/laravel/app/Notifications/OrderRequiresApprovalNotification.php
@@ -61,7 +61,7 @@ class OrderRequiresApprovalNotification extends Notification
             'related_entity_id' => $this->order->id,
             'type' => 'Pedido',
             'title' => 'Aprovação de Pedido',
-            'message' => 'O pedido com id ' . $this->order->id . ' com data de início breve, marcada para ' . $expected_begin_date . ', necessita de aprovação.',
+            'message' => 'O pedido com id ' . $this->order->id . ' com data de início marcada para ' . $expected_begin_date . ', necessita de aprovação.',
             'is_read' => false,
         ];
     }

--- a/laravel/database/migrations/2024_09_27_095051_create_orders_table.php
+++ b/laravel/database/migrations/2024_09_27_095051_create_orders_table.php
@@ -11,7 +11,6 @@ return new class extends Migration
      */
     public function up(): void
     {
-        //TODO: ADD MORE FOREIGN AS MORE TABLES ARE ADDED (STATUS)
         //TODO: IF A USER IS DELETED WHAT HAPPENS TO AN ORDER -> STATUS FOR EVERY TABLE SHOULD HOLD A DELETED OPTION INSTEAD OF REMOVING FROM DB
         Schema::create('orders', function (Blueprint $table) {
             $table->id();

--- a/laravel/database/migrations/2024_10_02_131142_create_vehicle_documents_table.php
+++ b/laravel/database/migrations/2024_10_02_131142_create_vehicle_documents_table.php
@@ -5,7 +5,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 // TODO: Should the document attributes include a file of the document itself?
-// TODO: MORE ATTRIBUTES?
 return new class extends Migration
 {
     /**

--- a/laravel/resources/js/Components/LeafletMap.jsx
+++ b/laravel/resources/js/Components/LeafletMap.jsx
@@ -63,7 +63,7 @@ function Routing({ routing, onLocationSelect, onTrajectoryChange }) {
         if (routing && !routingControlRef.current) {
             routingControlRef.current = L.Routing.control({
                 router: L.Routing.osrmv1({
-                    serviceUrl: `https://router.project-osrm.org/route/v1`, //TODO: route instructions to Portuguese
+                    serviceUrl: `https://router.project-osrm.org/route/v1`,
                 }),
                 geocoder: L.Control.Geocoder.nominatim({
 					geocodingQueryParams: {
@@ -72,7 +72,7 @@ function Routing({ routing, onLocationSelect, onTrajectoryChange }) {
                         viewbox: `${boundsSouthWestCorner[1]},${boundsSouthWestCorner[0]},${boundsNorthEastCorner[1]},${boundsNorthEastCorner[0]}`
                     }
 				}),
-                language: 'pt',
+                language: 'pt-PT',
             }).addTo(map);
 
 			routingControlRef.current.on('routesfound', function (e) {

--- a/laravel/resources/js/Layouts/AuthenticatedLayout.jsx
+++ b/laravel/resources/js/Layouts/AuthenticatedLayout.jsx
@@ -17,7 +17,6 @@ export default function Authenticated({ user, header, children }) {
             try {
                 const response = await axios.get('/notifications/unread-count');
                 setUnreadCount(response.data.unread_count);
-                console.log(response.data.unread_count)
 
             } catch (error) {
                 console.error('Error fetching unread notifications count', error);

--- a/laravel/resources/js/Layouts/AuthenticatedLayout.jsx
+++ b/laravel/resources/js/Layouts/AuthenticatedLayout.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import ApplicationLogo from '@/Components/ApplicationLogo';
 import Dropdown from '@/Components/Dropdown';
 import NavLink from '@/Components/NavLink';
@@ -8,6 +8,24 @@ import NotificationsIcon from '@mui/icons-material/Notifications';
 
 export default function Authenticated({ user, header, children }) {
     const [showingNavigationDropdown, setShowingNavigationDropdown] = useState(false);
+
+    const [unreadCount, setUnreadCount] = useState(0);
+
+    useEffect(() => {
+        // Fetch the unread notifications count from the back-end
+        const fetchUnreadCount = async () => {
+            try {
+                const response = await axios.get('/notifications/unread-count');
+                setUnreadCount(response.data.unread_count);
+                console.log(response.data.unread_count)
+
+            } catch (error) {
+                console.error('Error fetching unread notifications count', error);
+            }
+        };
+
+        fetchUnreadCount();
+    }, []);
 
     return (
         <div className="min-h-screen bg-sky-100">
@@ -156,25 +174,20 @@ export default function Authenticated({ user, header, children }) {
                         <div className="hidden md:flex sm:items-center sm:ms-6">
                             <Dropdown>
                                 <Dropdown.Trigger>
-                                    <span className="inline-flex rounded-md">
+                                    <span className="inline-flex rounded-md relative">
                                         <button
                                             type="button"
-                                            className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150"
+                                            className="relative inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150"
                                         >
+                                            {/* Bell Icon */}
                                             <NotificationsIcon />
 
-                                            <svg
-                                                className="ms-2 -me-0.5 h-4 w-4"
-                                                xmlns="http://www.w3.org/2000/svg"
-                                                viewBox="0 0 20 20"
-                                                fill="currentColor"
-                                            >
-                                                <path
-                                                    fillRule="evenodd"
-                                                    d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                                                    clipRule="evenodd"
-                                                />
-                                            </svg>
+                                            {/* Badge: Unread Count */}
+                                            {unreadCount > 0 && (
+                                                <span className="absolute top-0 right-0 inline-flex items-center justify-center px-2 py-1 text-xs font-bold leading-none text-white bg-red-600 rounded-full transform translate-x-1/2 -translate-y-1/2">
+                                                    {unreadCount}
+                                                </span>
+                                            )}
                                         </button>
                                     </span>
                                 </Dropdown.Trigger>

--- a/laravel/resources/js/Pages/Notifications/AllNotifications.jsx
+++ b/laravel/resources/js/Pages/Notifications/AllNotifications.jsx
@@ -6,12 +6,33 @@ import Table from '@/Components/Table';
 import { useEffect, useState } from 'react';
 
 export default function AllNotifications({auth, notifications, flash}) {
-
-    console.log(notifications);
-
     const [openSnackbar, setOpenSnackbar] = useState(false);
     const [snackbarMessage, setSnackbarMessage] = useState('');
     const [snackbarSeverity, setSnackbarSeverity] = useState('success'); // 'success' or 'error'
+
+    const markAsRead = async (notificationId) => {
+        try {
+            const response = await fetch(route('notifications.markAsRead', notificationId), {
+                method: 'PATCH',
+                headers: {
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+                    'Content-Type': 'application/json',
+                },
+            });
+
+            const result = await response.json();
+            setSnackbarMessage(result.message);
+            setSnackbarSeverity('success');
+
+            // Optionally, you can update the notifications state or refresh the page
+            // Here, you can filter out the marked notification if you want to update the UI immediately
+        } catch (error) {
+            setSnackbarMessage(error.message);
+            setSnackbarSeverity('error');
+        } finally {
+            setOpenSnackbar(true);
+        }
+    };
 
     return (
         <AuthenticatedLayout
@@ -30,6 +51,7 @@ export default function AllNotifications({auth, notifications, flash}) {
                             <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Mensagem</th>
                             <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tipo</th>
                             <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tipo (id)</th>
+                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Ação</th>
                         </tr>
                     </thead>
                     <tbody className="bg-white divide-y divide-gray-200">
@@ -40,6 +62,16 @@ export default function AllNotifications({auth, notifications, flash}) {
                                 <td className="px-6 py-4 max-w-[35%] whitespace-normal text-sm text-gray-900">{notification.message}</td>
                                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{notification.type}</td>
                                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{notification.related_entity_id}</td>
+                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                    {!notification.is_read && ( // Show button only if notification is unread
+                                        <button
+                                            onClick={() => markAsRead(notification.id)}
+                                            className="text-blue-600 hover:underline"
+                                        >
+                                            Marcar como lida
+                                        </button>
+                                    )}
+                                </td>
                             </tr>
                         ))}
                     </tbody>

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -85,6 +85,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/notifications', [NotificationController::class, 'index'])->name('notifications.index');
     Route::patch('/notifications/read/{notification}', [NotificationController::class, 'markAsRead'])->name('notifications.markAsRead');
     Route::delete('/notifications/delete/{notification}', [NotificationController::class, 'deleteNotification'])->name('notifications.delete');
+    Route::get('/notifications/unread-count', [NotificationController::class, 'getUnreadCount'])->name('notifications.unreadCount');
 
     //ORDERS
     Route::get('/orders', [OrderController::class, 'index'])->name('orders.index');

--- a/laravel/tests/Feature/Notifications/NotificationTest.php
+++ b/laravel/tests/Feature/Notifications/NotificationTest.php
@@ -120,15 +120,12 @@ class NotificationTest extends TestCase
             ->patch(route('notifications.markAsRead', ['notification' => $notification->id]));
 
         $response
-            ->assertSessionHasNoErrors()
-            ->assertRedirect('/notifications');
-
+            ->assertSessionHasNoErrors();
+            
         $this->assertDatabaseHas('notifications', [
             'id' => $notification->id,
             'is_read' => 1,
         ]);
-
-        $response->assertRedirect(route('notifications.index'));
     }
 
     public function test_user_marks_notification_as_read_fails_on_not_his_notification(): void

--- a/laravel/tests/Feature/Notifications/NotificationTest.php
+++ b/laravel/tests/Feature/Notifications/NotificationTest.php
@@ -131,7 +131,7 @@ class NotificationTest extends TestCase
         $response->assertRedirect(route('notifications.index'));
     }
 
-    public function test_user_marks_notification_as_read_fails_on_not_his_notification()
+    public function test_user_marks_notification_as_read_fails_on_not_his_notification(): void
     {
         $otherUser = User::factory()->create();
         $notification = Notification::factory()->create(['user_id' => $otherUser->id, 'is_read' => false]);
@@ -148,7 +148,7 @@ class NotificationTest extends TestCase
         $response->assertRedirect();
     }
 
-    public function test_user_can_delete_notification()
+    public function test_user_can_delete_notification(): void
     {
         $notification = Notification::factory()->create();
 
@@ -166,5 +166,23 @@ class NotificationTest extends TestCase
         $this->assertDatabaseMissing('notifications', [
             'id' => $notification->id,
         ]);
+    }
+
+    public function test_get_unread_count(): void
+    {
+        for ($i = 0; $i < rand(0,5); $i++) {
+            Notification::factory()->create(['user_id' => $this->user->id]);
+        }
+
+        Auth::login($this->user);
+
+        // Call the method to get the unread count
+        $response = $this->getJson(route('notifications.unreadCount'));
+
+        $unreadCount = Auth::user()->notifications->where('is_read', false)->count();
+
+        // Assert that the response is correct
+        $response->assertStatus(200)
+                 ->assertJson(['unread_count' => $unreadCount]);
     }
 }

--- a/laravel/tests/Feature/Notifications/Specific/DocumentExpiryNotificationTest.php
+++ b/laravel/tests/Feature/Notifications/Specific/DocumentExpiryNotificationTest.php
@@ -15,7 +15,6 @@ use App\Notifications\AccessoryExpiryNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Notifications\Messages\MailMessage;
 
-//TODO: MAIL TESTS AFTER IMPLEMENTING THEM
 class DocumentExpiryNotificationTest extends TestCase
 {
     use RefreshDatabase;

--- a/laravel/tests/Feature/Notifications/Specific/OrderCreationNotificationTest.php
+++ b/laravel/tests/Feature/Notifications/Specific/OrderCreationNotificationTest.php
@@ -6,41 +6,40 @@ use Tests\TestCase;
 use App\Models\User;
 use App\Models\Order;
 use Illuminate\Foundation\Testing\WithFaker;
+use App\Notifications\OrderCreationNotification;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Notifications\Messages\MailMessage;
-use App\Notifications\OrderRequiresApprovalNotification;
 
-class OrderRequiresApprovalNotificationTest extends TestCase
+class OrderCreationNotificationTest extends TestCase
 {
     use RefreshDatabase;
 
     public function test_toArray_stores_notification_correctly()
     {
-        // Create a user and order
+        // Create a user, vehicle, and kilometrage report
         $user = User::factory()->create();
         $order = Order::factory()->create();
 
         // Send notification
-        $notification = new OrderRequiresApprovalNotification($order);        
+        $notification = new OrderCreationNotification($order);
         $user->notify($notification);
 
+        // Check if the notification is stored in the database
         $this->assertDatabaseHas('notifications', [
             'user_id' => $user->id,
             'related_entity_id' => $order->id,
             'related_entity_type' => Order::class,
-            'type' => 'Pedido'
+            'type' => 'Pedido',
         ]);
     }
 
     public function test_toMail_sends_correct_notification()
     {
-        $order = Order::factory()->create([
-            'expected_begin_date' => now()->addDays(3), // Set a future date for testing
-        ]);
-        
+        $order = Order::factory()->create();
+
         // Create an instance of the notification
-        $notification = new OrderRequiresApprovalNotification($order);
+        $notification = new OrderCreationNotification($order);
 
         // Simulate a notifiable (could be a user or an anonymous notifiable)
         $notifiable = new AnonymousNotifiable();
@@ -48,12 +47,15 @@ class OrderRequiresApprovalNotificationTest extends TestCase
         // Act: Call the toMail method
         $mailMessage = $notification->toMail($notifiable);
 
-        $expected_begin_date = \Carbon\Carbon::parse($order->expected_begin_date)->format('d-m-Y H:i');
-
         // Assert: Verify that the mail message is properly structured
-        $this->assertInstanceOf(MailMessage::class, $mailMessage);
-        $this->assertStringContainsString('Pedido necessita de aprovação.', $mailMessage->introLines[0]);
+        $this->assertInstanceOf(MailMessage::class, $mailMessage); // Ensure the message is of type MailMessage
+        $this->assertStringContainsString('Novo pedido.', $mailMessage->introLines[0]); // Verify intro line
+
+        // Verify the action button URL contains the correct order id
         $this->assertStringContainsString(route('orders.edit', ['order' => $order->id]), $mailMessage->actionUrl);
-        $this->assertStringContainsString('O pedido com id ' . $order->id . ' com data de início marcada para ' . $expected_begin_date . ', necessita de aprovação.', $mailMessage->outroLines[0]);
+
+        // Verify the outro line contains the correct information about the order
+        $expectedBeginDate = \Carbon\Carbon::parse($order->expected_begin_date)->format('d-m-Y H:i');
+        $this->assertStringContainsString('Foi criado um novo pedido com id ' . $order->id . ' com data de início marcada para ' . $expectedBeginDate, $mailMessage->outroLines[0]);
     }
 }

--- a/laravel/tests/Feature/Notifications/Specific/OrderOccurrenceNotificationTest.php
+++ b/laravel/tests/Feature/Notifications/Specific/OrderOccurrenceNotificationTest.php
@@ -33,7 +33,7 @@ class OrderOccurrenceNotificationTest extends TestCase
             'user_id' => $user->id,
             'related_entity_id' => $order->id,
             'related_entity_type' => Order::class,
-            'type' => 'Pedido',
+            'type' => 'Ocorrência',
         ]);
     }
 


### PR DESCRIPTION
Header now shows the number of unread notifications of the user. This number doesn't update without a page refresh.

Created a button in the notifications table to mark them as read. Although the button works as intended the page needs refreshing for the newly read notifications not to show the mark as read button.

Created a new notification type and added triggers for it to send at the appropriate time.

Included unit tests to guarantee correct code behavior. 