### PR TITLE
Defined Gates for authorizing access

### DIFF
--- a/laravel/app/Http/Controllers/DriverController.php
+++ b/laravel/app/Http/Controllers/DriverController.php
@@ -14,11 +14,16 @@ use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
 use App\Rules\RoleUserTypeValidation;
 use App\Rules\DriverLicenseNumberValidation;
+use Illuminate\Support\Facades\Gate;
 
 class DriverController extends Controller
 {
     public function index() : Response
     {
+        if(! Gate::allows('view-driver')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed drivers page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -44,6 +49,10 @@ class DriverController extends Controller
 
     public function showCreateDriverForm()
     {
+        if(! Gate::allows('create-driver')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed drivers creation page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -55,6 +64,10 @@ class DriverController extends Controller
 
     public function createDriver(Request $request)
     {
+        if(! Gate::allows('create-driver')) {
+            abort(403);
+        }
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -124,6 +137,10 @@ class DriverController extends Controller
 
     public function showEditDriverForm(Driver $driver): Response
     {
+        if(! Gate::allows('edit-driver')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed drivers edit page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'driver_id' => $driver->user_id ?? null,
@@ -136,6 +153,10 @@ class DriverController extends Controller
 
     public function editDriver(Driver $driver, Request $request)
     {
+        if(! Gate::allows('edit-driver')) {
+            abort(403);
+        }
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -213,6 +234,10 @@ class DriverController extends Controller
 
     public function deleteDriver($id)
     {
+        if(! Gate::allows('delete-driver')) {
+            abort(403);
+        }
+
         DB::beginTransaction();
         try {
             $driver = Driver::findOrFail($id);

--- a/laravel/app/Http/Controllers/KidController.php
+++ b/laravel/app/Http/Controllers/KidController.php
@@ -10,11 +10,16 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
 use App\Rules\KidPlaceTypeValidation;
+use Illuminate\Support\Facades\Gate;
 
 class KidController extends Controller
 {
     public function index() //: Response
     {
+        if(! Gate::allows('view-kid')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed kids page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -35,6 +40,10 @@ class KidController extends Controller
 
     public function showCreateKidForm()
     {
+        if(! Gate::allows('create-kid')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed kid creation page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -54,6 +63,10 @@ class KidController extends Controller
 
     public function createKid(Request $request)
     {
+        if(! Gate::allows('create-kid')) {
+            abort(403);
+        }
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -98,6 +111,10 @@ class KidController extends Controller
 
     public function showEditKidForm(Kid $kid)
     {
+        if(! Gate::allows('edit-kid')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed kid edit page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'kid_id' => $kid->id ?? null,
@@ -113,6 +130,10 @@ class KidController extends Controller
 
     public function editKid(Kid $kid, Request $request)
     {
+        if(! Gate::allows('edit-kid')) {
+            abort(403);
+        }
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -162,6 +183,10 @@ class KidController extends Controller
 
     public function deleteKid($id)
     {
+        if(! Gate::allows('delete-kid')) {
+            abort(403);
+        }
+
         try {
             $kid = Kid::findOrFail($id);
             $kid->delete();
@@ -186,6 +211,10 @@ class KidController extends Controller
 
     public function showKidContacts(Kid $kid)
     {
+        if(! Gate::allows('view-kid')) {
+            abort(403);
+        }
+        
         Log::channel('user')->info('User accessed kids contact page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'kid_id' => $kid->id  ?? null,

--- a/laravel/app/Http/Controllers/KidEmailController.php
+++ b/laravel/app/Http/Controllers/KidEmailController.php
@@ -9,11 +9,16 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
+use Illuminate\Support\Facades\Gate;
 
 class KidEmailController extends Controller
 {
     public function showCreateKidEmailForm()
     {
+        if(! Gate::allows('create-kid')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed kid email creation page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -27,6 +32,10 @@ class KidEmailController extends Controller
 
     public function createKidEmail(Request $request)
     {
+        if(! Gate::allows('create-kid')) {
+            abort(403);
+        }
+
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
         $incomingFields = $request->validate([
@@ -64,6 +73,10 @@ class KidEmailController extends Controller
 
     public function showEditKidEmailForm(KidEmail $kidEmail)
     {
+        if(! Gate::allows('edit-kid')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed kid edit email page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'kid_id' => $kidEmail->id ?? null,
@@ -79,6 +92,10 @@ class KidEmailController extends Controller
 
     public function editKidEmail(KidEmail $kidEmail, Request $request)
     {
+        if(! Gate::allows('edit-kid')) {
+            abort(403);
+        }
+
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
         $incomingFields = $request->validate([
@@ -112,6 +129,10 @@ class KidEmailController extends Controller
 
     public function deleteKidEmail($id)
     {
+        if(! Gate::allows('delete-kid')) {
+            abort(403);
+        }
+
         try {
             $kidEmail = KidEmail::findOrFail($id);
             $kidId = $kidEmail->kid->id;

--- a/laravel/app/Http/Controllers/KidPhoneNumberController.php
+++ b/laravel/app/Http/Controllers/KidPhoneNumberController.php
@@ -9,11 +9,16 @@ use App\Models\KidPhoneNumber;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
+use Illuminate\Support\Facades\Gate;
 
 class KidPhoneNumberController extends Controller
 {
     public function showCreateKidPhoneNumberForm()
     {
+        if(! Gate::allows('create-kid')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed kid phone creation page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -27,6 +32,10 @@ class KidPhoneNumberController extends Controller
     
     public function createKidPhoneNumber(Request $request)
     {
+        if(! Gate::allows('create-kid')) {
+            abort(403);
+        }
+
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
         $incomingFields = $request->validate([
@@ -64,6 +73,10 @@ class KidPhoneNumberController extends Controller
 
     public function showEditKidPhoneNumberForm(KidPhoneNumber $kidPhoneNumber)
     {
+        if(! Gate::allows('edit-kid')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed kid phone edit page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'phone_id' => $kidPhoneNumber->id ?? null,
@@ -79,6 +92,10 @@ class KidPhoneNumberController extends Controller
 
     public function editKidPhoneNumber(KidPhoneNumber $kidPhoneNumber, Request $request)
     {
+        if(! Gate::allows('edit-kid')) {
+            abort(403);
+        }
+
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
         $incomingFields = $request->validate([
@@ -112,6 +129,10 @@ class KidPhoneNumberController extends Controller
 
     public function deleteKidPhoneNumber($id)
     {
+        if(! Gate::allows('delete-kid')) {
+            abort(403);
+        }
+
         try {
             $kidPhoneNumber = KidPhoneNumber::findOrFail($id);
             $kidId = $kidPhoneNumber->kid->id;

--- a/laravel/app/Http/Controllers/ManagerController.php
+++ b/laravel/app/Http/Controllers/ManagerController.php
@@ -10,11 +10,16 @@ use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
 use App\Rules\RoleUserTypeValidation;
+use Illuminate\Support\Facades\Gate;
 
 class ManagerController extends Controller
 {
     public function index() 
     {    
+        if(! Gate::allows('view-manager')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed managers page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -32,6 +37,10 @@ class ManagerController extends Controller
 
     public function showCreateManagerForm()
     {
+        if(! Gate::allows('create-manager')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed manager creation page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -49,6 +58,10 @@ class ManagerController extends Controller
 
     public function createManager(Request $request)
     {
+        if(! Gate::allows('create-manager')) {
+            abort(403);
+        }
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
         
@@ -87,6 +100,10 @@ class ManagerController extends Controller
 
     public function showEditManagerForm(User $user)
     {    
+        if(! Gate::allows('edit-manager')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed manager edit page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'manager_id' => $user->id ?? null,
@@ -103,6 +120,10 @@ class ManagerController extends Controller
 
     public function editManager(User $user, Request $request)
     {
+        if(! Gate::allows('edit-manager')) {
+            abort(403);
+        }
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -144,6 +165,10 @@ class ManagerController extends Controller
 
     public function deleteManager($id)
     {
+        if(! Gate::allows('delete-manager')) {
+            abort(403);
+        }
+
         try {
             $user = User::findOrFail($id);
             $user->update([
@@ -170,6 +195,10 @@ class ManagerController extends Controller
 
     public function showManagerApprovedOrders(User $user)
     {
+        if(! Gate::allows('view-manager')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed manager approved orders page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'manager_id' => $user->id ?? null,

--- a/laravel/app/Http/Controllers/OrderController.php
+++ b/laravel/app/Http/Controllers/OrderController.php
@@ -27,6 +27,7 @@ use App\Notifications\OrderCreationNotification;
 use App\Rules\EntityOrderAvailabilityValidation;
 use App\Notifications\OrderRequiresApprovalNotification;
 use App\Rules\KidDriverValidation;
+use Illuminate\Support\Facades\Gate;
 
 class OrderController extends Controller
 {
@@ -40,6 +41,8 @@ class OrderController extends Controller
 
     public function index()
     {
+        //Gate::authorize('viewAny', Order::class);
+        
         Log::channel('user')->info('User accessed orders page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -67,6 +70,11 @@ class OrderController extends Controller
 
     public function showCreateOrderForm()
     {
+
+        if(! Gate::allows('create-order')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed order creation page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -96,6 +104,15 @@ class OrderController extends Controller
 
     public function createOrder(Request $request)
     {
+
+        // if ($request->user()->cannot('create')) {
+        //     abort(403);
+        // }
+
+        if(! Gate::allows('create-order')){
+            abort(403);
+        };
+
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
         $kidsCount = count($request->input('places.*.kid_id', []));
@@ -213,6 +230,12 @@ class OrderController extends Controller
 
     public function showEditOrderForm(Order $order)
     {
+
+        if(! Gate::allows('edit-order')){
+            abort(403);
+            //return redirect()->route('orders.index')->with('error', 'Não tem permissões para editar o pedido.');
+        };
+        
         Log::channel('user')->info('User accessed order edit page', [
                 'auth_user_id' => $this->loggedInUserId ?? null,
                 'order_id' => $order->id ?? null,
@@ -248,6 +271,11 @@ class OrderController extends Controller
 
     public function editOrder(Order $order, Request $request)
     {
+
+        if(! Gate::allows('edit-order')){
+            abort(403);
+        };
+
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
         $kidsCount = count($request->input('places.*.kid_id', []));
@@ -364,6 +392,10 @@ class OrderController extends Controller
 
     public function deleteOrder($id)
     {
+        if(! Gate::allows('delete-order')){
+            abort(403);
+        };
+
         try {
             $order = Order::findOrFail($id);
             $order->delete();

--- a/laravel/app/Http/Controllers/OrderController.php
+++ b/laravel/app/Http/Controllers/OrderController.php
@@ -421,6 +421,11 @@ class OrderController extends Controller
     //TODO: Add Administrators Role
     public function approveOrder(Order $order, Request $request) 
     {
+
+        if(! Gate::allows('approve-order')){
+            abort(403);
+        };
+
         $incomingFields = $request->validate([
             'manager_id' => [
                 'required', 
@@ -456,6 +461,10 @@ class OrderController extends Controller
 
     public function removeOrderApproval(Order $order, Request $request) 
     {
+        if(! Gate::allows('approve-order')){
+            abort(403);
+        };
+        
         $request->validate([
             'manager_id' => [
                 'required', 

--- a/laravel/app/Http/Controllers/OrderOccurrenceController.php
+++ b/laravel/app/Http/Controllers/OrderOccurrenceController.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
 use App\Notifications\OrderOccurrenceNotification;
+use Illuminate\Support\Facades\Gate;
 
 class OrderOccurrenceController extends Controller
 {
@@ -42,6 +43,11 @@ class OrderOccurrenceController extends Controller
 
     public function showCreateOrderOccurrenceForm()
     {
+
+        if(! Gate::allows('create-order-occurrence')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed occurrence creation page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -55,6 +61,10 @@ class OrderOccurrenceController extends Controller
 
     public function createOrderOccurrence(Request $request)
     {
+        if(! Gate::allows('create-order-occurrence')){
+            abort(403);
+        };
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -104,6 +114,10 @@ class OrderOccurrenceController extends Controller
 
     public function showEditOrderOccurrenceForm(OrderOccurrence $orderOccurrence)
     {
+        if(! Gate::allows('edit-order-occurrence', $orderOccurrence)){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed occurrence edit page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'occurrence_id' => $orderOccurrence->id ?? null,
@@ -119,6 +133,11 @@ class OrderOccurrenceController extends Controller
 
     public function editOrderOccurrence(OrderOccurrence $orderOccurrence, Request $request)
     {
+
+        if(! Gate::allows('edit-order-occurrence', $orderOccurrence)){
+            abort(403);
+        };
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -159,6 +178,10 @@ class OrderOccurrenceController extends Controller
 
     public function deleteOrderOccurrence($id)
     {
+        if(! Gate::allows('delete-order-occurrence')){
+            abort(403);
+        };
+
         try {
             $orderOccurrence = OrderOccurrence::findOrFail($id);
             $orderId = $orderOccurrence->order->id;

--- a/laravel/app/Http/Controllers/OrderRouteController.php
+++ b/laravel/app/Http/Controllers/OrderRouteController.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
 use App\Rules\TechnicianUserTypeValidation;
+use Illuminate\Support\Facades\Gate;
 use MatanYadaev\EloquentSpatial\Objects\Point;
 use MatanYadaev\EloquentSpatial\Objects\Polygon;
 use MatanYadaev\EloquentSpatial\Objects\LineString;
@@ -39,6 +40,11 @@ class OrderRouteController extends Controller
 
     public function showCreateOrderRouteForm()
     {
+
+        if(! Gate::allows('create-order-route')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed order route creation page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -54,6 +60,10 @@ class OrderRouteController extends Controller
 
     public function createOrderRoute(Request $request)
     {
+        if(! Gate::allows('create-order-route')){
+            abort(403);
+        };
+
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
         
         $incomingFields = $request->validate([
@@ -129,6 +139,10 @@ class OrderRouteController extends Controller
 
     public function showEditOrderRouteForm(OrderRoute $orderRoute): Response
     {
+        if(! Gate::allows('edit-order-route')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed order route edit page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'route_id' => $orderRoute->id ?? null,
@@ -147,6 +161,11 @@ class OrderRouteController extends Controller
 
     public function editOrderRoute(OrderRoute $orderRoute, Request $request)
     {
+
+        if(! Gate::allows('create-order-route')){
+            abort(403);
+        };
+
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
         $incomingFields = $request->validate([
             'name' => ['required', 'string', 'max:255'],
@@ -218,6 +237,10 @@ class OrderRouteController extends Controller
 
     public function deleteOrderRoute($id)
     {
+        if(! Gate::allows('delete-order-route')){
+            abort(403);
+        };
+
         try {
             $orderRoute = OrderRoute::findOrFail($id);
             $orderRoute->delete();

--- a/laravel/app/Http/Controllers/OrderStopController.php
+++ b/laravel/app/Http/Controllers/OrderStopController.php
@@ -6,6 +6,7 @@ use App\Models\OrderStop;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
+use Illuminate\Support\Facades\Gate;
 
 // This class doesn't need to implement transactions because it is only
 // called by the order controller which already implements its own
@@ -13,6 +14,10 @@ class OrderStopController extends Controller
 {
     public function createOrderStop(Request $request)
     {
+        if(! Gate::allows('create-order-stop')){
+            abort(403);
+        };
+
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
         $incomingFields = $request->validate([
@@ -65,6 +70,10 @@ class OrderStopController extends Controller
     // TODO: WHAT ELSE SHOULD THIS EDIT INCLUDE?
     public function editOrderStop(OrderStop $orderStop, Request $request)
     {
+        if(! Gate::allows('edit-order-stop')){
+            abort(403);
+        };
+
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
         $incomingFields = $request->validate([
@@ -96,6 +105,10 @@ class OrderStopController extends Controller
 
     public function deleteOrderStop($id)
     {
+        if(! Gate::allows('delete-order-stop')){
+            abort(403);
+        };
+
         try {
             $orderStop = OrderStop::findOrFail($id);
             $order = $orderStop->order;

--- a/laravel/app/Http/Controllers/PlaceController.php
+++ b/laravel/app/Http/Controllers/PlaceController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
+use Illuminate\Support\Facades\Gate;
 use MatanYadaev\EloquentSpatial\Objects\Point;
 
 class PlaceController extends Controller
@@ -32,6 +33,10 @@ class PlaceController extends Controller
 
     public function showCreatePlaceForm()
     {
+        if(! Gate::allows('create-place')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed place creation page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -41,6 +46,10 @@ class PlaceController extends Controller
 
     public function createPlace(Request $request)
     {
+        if(! Gate::allows('create-place')){
+            abort(403);
+        };
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -84,6 +93,10 @@ class PlaceController extends Controller
 
     public function showEditPlaceForm(Place $place)
     {
+        if(! Gate::allows('edit-place')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed place edit page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'place_id' => $place->id ?? null,
@@ -95,6 +108,10 @@ class PlaceController extends Controller
 
     public function editPlace(Place $place, Request $request)
     {
+        if(! Gate::allows('edit-place')){
+            abort(403);
+        };
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -139,6 +156,10 @@ class PlaceController extends Controller
 
     public function deletePlace($id)
     {
+        if(! Gate::allows('delete-place')){
+            abort(403);
+        };
+
         try {
             $place = Place::findOrFail($id);
             $place->delete();

--- a/laravel/app/Http/Controllers/TechnicianController.php
+++ b/laravel/app/Http/Controllers/TechnicianController.php
@@ -8,11 +8,16 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
+use Illuminate\Support\Facades\Gate;
 
 class TechnicianController extends Controller
 {
     public function index()
     {
+        if(! Gate::allows('view-user')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed technicians page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -31,6 +36,10 @@ class TechnicianController extends Controller
 
     public function showCreateTechnicianForm()
     {
+        if(! Gate::allows('create-user')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed technician creation page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -48,6 +57,10 @@ class TechnicianController extends Controller
 
     public function createTechnician(Request $request)
     {
+        if(! Gate::allows('create-user')) {
+            abort(403);
+        }
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -94,6 +107,10 @@ class TechnicianController extends Controller
 
     public function showEditTechnicianForm(User $user)
     {
+        if(! Gate::allows('edit-user')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed technician edit page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'technician_id' => $user->id ?? null,
@@ -110,6 +127,10 @@ class TechnicianController extends Controller
 
     public function editTechnician(User $user, Request $request)
     {
+        if(! Gate::allows('edit-user')) {
+            abort(403);
+        }
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
         
@@ -151,6 +172,10 @@ class TechnicianController extends Controller
 
     public function deleteTechnician($id)
     {
+        if(! Gate::allows('delete-user')) {
+            abort(403);
+        }
+
         try {
             $user = User::findOrFail($id);
             $user->update([

--- a/laravel/app/Http/Controllers/UserController.php
+++ b/laravel/app/Http/Controllers/UserController.php
@@ -11,12 +11,17 @@ use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules;
 use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Hash;
 
 class UserController extends Controller
 {
     public function index()
     {
+        if(! Gate::allows('view-user')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed users page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -38,6 +43,10 @@ class UserController extends Controller
 
     public function showCreateUserForm()
     {
+        if(! Gate::allows('create-user')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed user creation page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -52,6 +61,10 @@ class UserController extends Controller
 
     public function createUser(Request $request)
     {
+        if(! Gate::allows('create-user')) {
+            abort(403);
+        }
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -98,6 +111,10 @@ class UserController extends Controller
 
     public function showEditUserForm(User $user)
     {
+        if(! Gate::allows('edit-user')) {
+            abort(403);
+        }
+
         Log::channel('user')->info('User accessed user edit page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'user_id' => $user->id ?? null,
@@ -114,6 +131,10 @@ class UserController extends Controller
 
     public function editUser(User $user, Request $request)
     {
+        if(! Gate::allows('edit-user')) {
+            abort(403);
+        }
+
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
         $incomingFields = $request->validate([
@@ -151,6 +172,10 @@ class UserController extends Controller
 
     public function deleteUser($id)
     {
+        if(! Gate::allows('delete-user')) {
+            abort(403);
+        }
+
         try {
             $user = User::findOrFail($id);
             $user->delete();

--- a/laravel/app/Http/Controllers/VehicleAccessoryController.php
+++ b/laravel/app/Http/Controllers/VehicleAccessoryController.php
@@ -10,11 +10,16 @@ use Illuminate\Validation\Rule;
 use App\Models\VehicleAccessory;
 use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
+use Illuminate\Support\Facades\Gate;
 
 class VehicleAccessoryController extends Controller
 {
     public function index()
     {
+        if(! Gate::allows('view-vehicle-accessory')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed vehicles accessories page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -36,6 +41,10 @@ class VehicleAccessoryController extends Controller
 
     public function showCreateVehicleAccessoryForm()
     {
+        if(! Gate::allows('create-vehicle-accessory')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed vehicle accessory creation page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -49,6 +58,10 @@ class VehicleAccessoryController extends Controller
 
     public function createVehicleAccessory(Request $request)
     {
+        if(! Gate::allows('create-vehicle-accessory')){
+            abort(403);
+        };
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -92,6 +105,10 @@ class VehicleAccessoryController extends Controller
 
     public function showEditVehicleAccessoryForm(VehicleAccessory $vehicleAccessory)
     {
+        if(! Gate::allows('edit-vehicle-accessory')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed vehicle accessory edit page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'accessory_id' => $vehicleAccessory->id ?? null,
@@ -107,6 +124,10 @@ class VehicleAccessoryController extends Controller
 
     public function editVehicleAccessory(VehicleAccessory $vehicleAccessory, Request $request)
     {
+        if(! Gate::allows('edit-vehicle-accessory')){
+            abort(403);
+        };
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -150,6 +171,10 @@ class VehicleAccessoryController extends Controller
 
     public function deleteVehicleAccessory($id)
     {
+        if(! Gate::allows('delete-vehicle-accessory')){
+            abort(403);
+        };
+
         try {
             $vehicleAccessory = VehicleAccessory::findOrFail($id);
             $vehicleId = $vehicleAccessory->vehicle->id;

--- a/laravel/app/Http/Controllers/VehicleController.php
+++ b/laravel/app/Http/Controllers/VehicleController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Storage;
 
 class VehicleController extends Controller
@@ -45,6 +46,10 @@ class VehicleController extends Controller
 
     public function showCreateVehicleForm()
     {
+        if(! Gate::allows('create-vehicle')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed vehicle creation page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -54,6 +59,10 @@ class VehicleController extends Controller
 
     public function createVehicle(Request $request)
     {
+        if(! Gate::allows('create-vehicle')){
+            abort(403);
+        };
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -143,6 +152,10 @@ class VehicleController extends Controller
 
     public function showEditVehicleForm(Vehicle $vehicle)
     {
+        if(! Gate::allows('edit-vehicle', $vehicle)){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed vehicle edit page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'vehicle_id' => $vehicle->id ?? null,
@@ -153,6 +166,10 @@ class VehicleController extends Controller
 
     public function editVehicle(Vehicle $vehicle, Request $request)
     {
+        if(! Gate::allows('edit-vehicle', $vehicle)){
+            abort(403);
+        };
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -247,6 +264,10 @@ class VehicleController extends Controller
 
     public function deleteVehicle($id)
     {
+        if(! Gate::allows('delete-vehicle')){
+            abort(403);
+        };
+
         try {
             $vehicle = Vehicle::findOrFail($id);
             $vehicle->delete();

--- a/laravel/app/Http/Controllers/VehicleController.php
+++ b/laravel/app/Http/Controllers/VehicleController.php
@@ -324,6 +324,10 @@ class VehicleController extends Controller
 
     public function showVehicleKilometrageReports(Vehicle $vehicle)
     {
+        if(! Gate::allows('view-vehicle-report')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed a vehicle kilometrage reports page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'vehicle_id' => $vehicle->id ?? null,
@@ -347,6 +351,10 @@ class VehicleController extends Controller
 
     public function showVehicleRefuelRequests(Vehicle $vehicle)
     {
+        if(! Gate::allows('view-vehicle-refuel-request')){
+            abort(403);
+        };
+        
         Log::channel('user')->info('User accessed a vehicle refuel requests page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'vehicle_id' => $vehicle->id ?? null,
@@ -370,6 +378,10 @@ class VehicleController extends Controller
 
     public function showVehicleMaintenanceReports(Vehicle $vehicle)
     {
+        if(! Gate::allows('view-vehicle-report')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed a vehicle maintenance reports page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'vehicle_id' => $vehicle->id ?? null,

--- a/laravel/app/Http/Controllers/VehicleDocumentController.php
+++ b/laravel/app/Http/Controllers/VehicleDocumentController.php
@@ -10,11 +10,16 @@ use App\Models\VehicleDocument;
 use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
 use App\Rules\VehicleDocumentDataValidation;
+use Illuminate\Support\Facades\Gate;
 
 class VehicleDocumentController extends Controller
 {
     public function index()
     {
+        if(! Gate::allows('view-vehicle-doc')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed vehicle documents page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -38,6 +43,10 @@ class VehicleDocumentController extends Controller
 
     public function showCreateVehicleDocumentForm()
     {
+        if(! Gate::allows('create-vehicle-doc')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed vehicle document creation page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -51,6 +60,10 @@ class VehicleDocumentController extends Controller
 
     public function createVehicleDocument(Request $request)
     {
+        if(! Gate::allows('create-vehicle-doc')){
+            abort(403);
+        };
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -109,6 +122,10 @@ class VehicleDocumentController extends Controller
 
     public function showEditVehicleDocumentForm(VehicleDocument $vehicleDocument)
     {
+        if(! Gate::allows('edit-vehicle-doc')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed vehicle document edit page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'document_id' => $vehicleDocument->id ?? null,
@@ -124,6 +141,10 @@ class VehicleDocumentController extends Controller
 
     public function editVehicleDocument(VehicleDocument $vehicleDocument, Request $request)
     {
+        if(! Gate::allows('edit-vehicle-doc')){
+            abort(403);
+        };
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -182,6 +203,10 @@ class VehicleDocumentController extends Controller
 
     public function deleteVehicleDocument($id)
     {
+        if(! Gate::allows('delete-vehicle-doc')){
+            abort(403);
+        };
+
         try {
             $vehicleDocument = VehicleDocument::findOrFail($id);
             $vehicleId = $vehicleDocument->vehicle->id;

--- a/laravel/app/Http/Controllers/VehicleKilometrageReportController.php
+++ b/laravel/app/Http/Controllers/VehicleKilometrageReportController.php
@@ -9,11 +9,16 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
 use App\Models\VehicleKilometrageReport;
+use Illuminate\Support\Facades\Gate;
 
 class VehicleKilometrageReportController extends Controller
 {
     public function showCreateVehicleKilometrageReportForm()
     {
+        if(! Gate::allows('create-vehicle-report')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed vehicle kilometrage report entry creation page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -29,6 +34,10 @@ class VehicleKilometrageReportController extends Controller
 
     public function createVehicleKilometrageReport(Request $request)
     {
+        if(! Gate::allows('create-vehicle-report')){
+            abort(403);
+        };
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -64,6 +73,10 @@ class VehicleKilometrageReportController extends Controller
 
     public function showEditVehicleKilometrageReportForm(VehicleKilometrageReport $vehicleKilometrageReport)
     {
+        if(! Gate::allows('edit-vehicle-report')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed vehicle kilometrage report entry edit page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'kilometrage_report_id' => $vehicleKilometrageReport->id,
@@ -81,6 +94,10 @@ class VehicleKilometrageReportController extends Controller
 
     public function editVehicleKilometrageReport(VehicleKilometrageReport $vehicleKilometrageReport, Request $request)
     {
+        if(! Gate::allows('edit-vehicle-report')){
+            abort(403);
+        };
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -116,6 +133,10 @@ class VehicleKilometrageReportController extends Controller
 
     public function deleteVehicleKilometrageReport($id)
     {
+        if(! Gate::allows('delete-vehicle-report')){
+            abort(403);
+        };
+
         try {
             $report = VehicleKilometrageReport::findOrFail($id);
             $vehicleId = $report->vehicle->id;

--- a/laravel/app/Http/Controllers/VehicleMaintenanceReportController.php
+++ b/laravel/app/Http/Controllers/VehicleMaintenanceReportController.php
@@ -10,11 +10,16 @@ use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
 use App\Models\VehicleMaintenanceReport;
+use Illuminate\Support\Facades\Gate;
 
 class VehicleMaintenanceReportController extends Controller
 {
     public function index()
     {
+        if(! Gate::allows('view-vehicle-report')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed maintenance reports page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -37,6 +42,10 @@ class VehicleMaintenanceReportController extends Controller
 
     public function showCreateVehicleMaintenanceReportForm()
     {
+        if(! Gate::allows('create-vehicle-report')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed vehicle maintenance report creation page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -50,6 +59,10 @@ class VehicleMaintenanceReportController extends Controller
 
     public function createVehicleMaintenanceReport(Request $request)
     {
+        if(! Gate::allows('create-vehicle-report')){
+            abort(403);
+        };
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -121,6 +134,10 @@ class VehicleMaintenanceReportController extends Controller
 
     public function showEditVehicleMaintenanceReportForm(VehicleMaintenanceReport $vehicleMaintenanceReport)
     {
+        if(! Gate::allows('edit-vehicle-report')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed vehicle maintenance report edit page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'maintenance_report_id' => $vehicleMaintenanceReport->id,
@@ -141,6 +158,10 @@ class VehicleMaintenanceReportController extends Controller
 
     public function editVehicleMaintenanceReport(VehicleMaintenanceReport $vehicleMaintenanceReport, Request $request)
     {
+        if(! Gate::allows('edit-vehicle-report')){
+            abort(403);
+        };
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -209,6 +230,10 @@ class VehicleMaintenanceReportController extends Controller
 
     public function deleteVehicleMaintenanceReport($id)
     {
+        if(! Gate::allows('edit-vehicle-report')){
+            abort(403);
+        };
+
         try {
             $report = VehicleMaintenanceReport::findOrFail($id);
             $vehicleId = $report->vehicle->id;

--- a/laravel/app/Http/Controllers/VehicleRefuelRequestController.php
+++ b/laravel/app/Http/Controllers/VehicleRefuelRequestController.php
@@ -11,11 +11,16 @@ use Illuminate\Support\Facades\Log;
 use App\Helpers\ErrorMessagesHelper;
 use App\Models\VehicleRefuelRequest;
 use App\Notifications\VehicleRefuelRequestNotification;
+use Illuminate\Support\Facades\Gate;
 
 class VehicleRefuelRequestController extends Controller
 {
     public function showCreateVehicleRefuelRequestForm()
     {
+        if(! Gate::allows('create-vehicle-refuel-request')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed vehicle refuel request creation page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
@@ -29,6 +34,10 @@ class VehicleRefuelRequestController extends Controller
 
     public function createVehicleRefuelRequest(Request $request)
     {
+        if(! Gate::allows('create-vehicle-refuel-request')){
+            abort(403);
+        };
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -90,6 +99,10 @@ class VehicleRefuelRequestController extends Controller
 
     public function showEditVehicleRefuelRequestForm(VehicleRefuelRequest $vehicleRefuelRequest)
     {
+        if(! Gate::allows('edit-vehicle-refuel-request')){
+            abort(403);
+        };
+
         Log::channel('user')->info('User accessed vehicle refuel request edit page', [
             'auth_user_id' => $this->loggedInUserId ?? null,
             'refuel_request_id' => $vehicleRefuelRequest->id,
@@ -105,6 +118,10 @@ class VehicleRefuelRequestController extends Controller
 
     public function editVehicleRefuelRequest(VehicleRefuelRequest $vehicleRefuelRequest, Request $request)
     {
+        if(! Gate::allows('edit-vehicle-refuel-request')){
+            abort(403);
+        };
+
         // Load custom error messages from helper
         $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
 
@@ -144,6 +161,10 @@ class VehicleRefuelRequestController extends Controller
 
     public function deleteVehicleRefuelRequest($id)
     {
+        if(! Gate::allows('delete-vehicle-refuel-request')){
+            abort(403);
+        };
+
         try {
             $request = VehicleRefuelRequest::findOrFail($id);
             $vehicleId = $request->vehicle->id;

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -105,4 +105,14 @@ class User extends Authenticatable
     {
         return $this->user_type === 'Gestor';
     }
+
+    public function isTechnician()
+    {
+        return $this->user_type === 'Técnico';
+    }
+
+    public function isDriver()
+    {
+        return $this->user_type === 'Condutor';
+    }
 }

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -95,4 +95,14 @@ class User extends Authenticatable
     {
         return $this->morphMany(Notification::class, 'related_entity');
     }
+
+    public function isAdmin()
+    {
+        return $this->user_type === 'Administrador';
+    }
+
+    public function isManager()
+    {
+        return $this->user_type === 'Gestor';
+    }
 }

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -113,6 +113,6 @@ class User extends Authenticatable
 
     public function isDriver()
     {
-        return $this->user_type === 'Condutor';
+        return ($this->user_type === 'Condutor' && $this->driver()->exists());
     }
 }

--- a/laravel/app/Policies/OrderPolicy.php
+++ b/laravel/app/Policies/OrderPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Driver;
+use App\Models\Order;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class OrderPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        //  
+        return $user->isAdmin() || $user->isManager();
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    // public function view(User $user, Order $order): bool
+    // {
+    //     //
+    //     return (auth()->$user->isAdmin() || auth()->$user->isManager() || (auth()->$user->check() && $order->$user->id == auth()->id));
+    // }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        //
+        return $user->user_type == 'Administrador' || $user->user_type == 'Gestor';
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Order $order): bool
+    {
+        //
+        return $user->user_type == 'Administrador' || $user->user_type == 'Gestor';
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Order $order): bool
+    {
+        //
+        return $user->user_type == 'Administrador' || $user->user_type == 'Gestor';
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Order $order): bool
+    {
+        //
+        return $user->user_type == 'Administrador';
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Order $order): bool
+    {
+        //
+        return $user->user_type == 'Administrador';
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -134,6 +134,7 @@ class AppServiceProvider extends ServiceProvider
         });
 
         // Kid Gates
+        // Re-used these gates for KidEmails and KidPhoneNumbers since same logic applies
         Gate::define('view-kid', function (User $user) {
             return $user->isAdmin() || $user->isManager() || $user->isTechnician()
             ? Response::allow()
@@ -158,6 +159,81 @@ class AppServiceProvider extends ServiceProvider
                 : Response::denyWithStatus(403);
         });
 
-       
+        // User Gates
+        // Re-used gates for Techinicians since same logic applies
+        Gate::define('view-user', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('create-user', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('edit-user', function (User $user) {
+            return $user->isAdmin() || $user->isManager() //TODO: should user be able to edit own data?
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('delete-user', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        // Manager Gates
+        Gate::define('view-manager', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('create-manager', function (User $user) {
+            return $user->isAdmin()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('edit-manager', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('delete-manager', function (User $user) {
+            return $user->isAdmin()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        // Driver Gates
+        ////TODO: should Drivers use same logic as Users?
+        Gate::define('view-driver', function (User $user) {
+            return $user->isAdmin() || $user->isManager() || $user->isDriver()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('create-driver', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('edit-driver', function (User $user) {
+            return $user->isAdmin() || $user->isManager()  //TODO: should driver be able to edit own data?
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('delete-driver', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
     }
 }

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -114,5 +114,25 @@ class AppServiceProvider extends ServiceProvider
                 : Response::denyWithStatus(403);
         });
 
+        // Address Gates
+        Gate::define('create-place', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('edit-place', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('delete-place', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        
     }
 }

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Models\OrderOccurrence;
 use App\Models\User;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Support\Facades\Gate;
@@ -24,6 +25,14 @@ class AppServiceProvider extends ServiceProvider
     {
         require_once app_path('Helpers/ErrorMessagesHelper.php');
 
+        //Grants all abilities to Admin users
+        Gate::before(function (User $user, string $ability) {
+            if($user->isAdmin()) {
+                return true;
+            }
+        });
+
+        // Order Gates
         Gate::define('create-order', function (User $user) {
             return $user->isAdmin() || $user->isManager()
                 ? Response::allow()
@@ -37,6 +46,50 @@ class AppServiceProvider extends ServiceProvider
         });
 
         Gate::define('delete-order', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('approve-order', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        // Order Occurrence Gates
+        Gate::define('create-order-occurrence', function (User $user) {
+            return $user->isAdmin() || $user->isManager() || $user->isDriver()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('edit-order-occurrence', function (User $user, OrderOccurrence $occurence) {
+            return $user->isAdmin() || $user->isManager() || $user->isDriver()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('delete-order-occurrence', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        // Order Route Gates
+        Gate::define('create-order-route', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('edit-order-route', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('delete-order-route', function (User $user) {
             return $user->isAdmin() || $user->isManager()
                 ? Response::allow()
                 : Response::denyWithStatus(403);

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -20,5 +23,23 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         require_once app_path('Helpers/ErrorMessagesHelper.php');
+
+        Gate::define('create-order', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('edit-order', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('delete-order', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
     }
 }

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -133,6 +133,31 @@ class AppServiceProvider extends ServiceProvider
                 : Response::denyWithStatus(403);
         });
 
-        
+        // Kid Gates
+        Gate::define('view-kid', function (User $user) {
+            return $user->isAdmin() || $user->isManager() || $user->isTechnician()
+            ? Response::allow()
+            : Response::denyWithStatus(403);
+        });
+
+        Gate::define('create-kid', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('edit-kid', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('delete-kid', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+       
     }
 }

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Models\OrderOccurrence;
 use App\Models\User;
+use App\Models\Vehicle;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
@@ -65,7 +66,7 @@ class AppServiceProvider extends ServiceProvider
         });
 
         Gate::define('edit-order-occurrence', function (User $user, OrderOccurrence $occurence) {
-            return $user->isAdmin() || $user->isManager() || $user->isDriver()
+            return $user->isAdmin() || $user->isManager() || ($user->isDriver() && $occurence->order()->driver() === $user->id())   //Check if driver is the one in the order 
                 ? Response::allow()
                 : Response::denyWithStatus(403);
         });
@@ -235,5 +236,26 @@ class AppServiceProvider extends ServiceProvider
                 ? Response::allow()
                 : Response::denyWithStatus(403);
         });
+
+        //Vehicle Gates
+        Gate::define('create-vehicle', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('edit-vehicle', function (User $user, Vehicle $vehicle) {
+            return $user->isAdmin() || $user->isManager()       //TODO: should Drivers be able to edit vehicle?
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('delete-vehicle', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        
     }
 }

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -26,6 +26,13 @@ class AppServiceProvider extends ServiceProvider
     {
         require_once app_path('Helpers/ErrorMessagesHelper.php');
 
+        /*
+            ## DISCLAIMER: 
+                The use of gates was just a quick way to prevent unauthorized access to resources!! NOT OPTIMAL
+                In the future more future proof ways should be considered, such as using Laravel policies combined with gates, or 
+                through the use of a library like Spatie. This may require changes on the database level such as creating a new table for roles.
+        */
+
         //Grants all abilities to Admin users
         Gate::before(function (User $user, string $ability) {
             if($user->isAdmin()) {
@@ -256,6 +263,56 @@ class AppServiceProvider extends ServiceProvider
                 : Response::denyWithStatus(403);
         });
 
-        
+        //Vehicle Documents Gates
+        Gate::define('view-vehicle-doc', function (User $user) {
+            return $user->isAdmin() || $user->isManager() || $user->isDriver()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('create-vehicle-doc', function (User $user) {
+            return $user->isAdmin() || $user->isManager()       //TODO: should Drivers be able to create vehicle documents?
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('edit-vehicle-doc', function (User $user) {
+            return $user->isAdmin() || $user->isManager()       //TODO: should Drivers be able to edit vehicle documents?
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('delete-vehicle-doc', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        //Vehicle Accessories Gates
+        Gate::define('view-vehicle-accessory', function (User $user) {
+            return $user->isAdmin() || $user->isManager() || $user->isDriver()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('create-vehicle-accessory', function (User $user) {
+            return $user->isAdmin() || $user->isManager()       //TODO: should Drivers be able to create vehicle acessories?
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('edit-vehicle-accessory', function (User $user) {
+            return $user->isAdmin() || $user->isManager()       //TODO: should Drivers be able to edit vehicle acessories?
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('delete-vehicle-accessory', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+
     }
 }

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -313,6 +313,55 @@ class AppServiceProvider extends ServiceProvider
                 : Response::denyWithStatus(403);
         });
 
+        // Vehicle Reports Gates
+        // Reports can be Kilometrage or maintenance
+        Gate::define('view-vehicle-report', function (User $user) {
+            return $user->isAdmin() || $user->isManager() || $user->isDriver()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
 
+        Gate::define('create-vehicle-report', function (User $user) {
+            return $user->isAdmin() || $user->isManager() || $user->isDriver()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('edit-vehicle-report', function (User $user) {
+            return $user->isAdmin() || $user->isManager() || $user->isDriver()       //TODO: should Drivers be able to edit vehicle reports?
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('delete-vehicle-report', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        // Vehicle Refuel Requests
+        Gate::define('view-vehicle-refuel-request', function (User $user) {
+            return $user->isAdmin() || $user->isManager() || $user->isDriver()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('create-vehicle-refuel-request', function (User $user) {
+            return $user->isAdmin() || $user->isManager() || $user->isDriver()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('edit-vehicle-refuel-request', function (User $user) {
+            return $user->isAdmin() || $user->isManager() || $user->isDriver()       //TODO: should Drivers be able to edit vehicle refuel requests?
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('delete-vehicle-refuel-request', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
     }
 }

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -94,5 +94,25 @@ class AppServiceProvider extends ServiceProvider
                 ? Response::allow()
                 : Response::denyWithStatus(403);
         });
+
+        //
+        Gate::define('create-order-stop', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('edit-order-stop', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('delete-order-stop', function (User $user) {
+            return $user->isAdmin() || $user->isManager()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
     }
 }

--- a/laravel/resources/js/Pages/OrderOccurrences/AllOrderOccurrences.jsx
+++ b/laravel/resources/js/Pages/OrderOccurrences/AllOrderOccurrences.jsx
@@ -27,8 +27,8 @@ export default function AllOrderOccurences({auth, occurrences, flash}) {
             id: occurrence.id,
             date: occurrence.order.expected_begin_date,
             order_id: occurrence.order_id,
-            driver_id: occurrence.order.driver.user_id,
-            vehicle_id: occurrence.order.vehicle.id,
+            driver_id: occurrence.order.driver,
+            vehicle_id: occurrence.order.vehicle,
             type: occurrence.type,
             vehicle_towed: occurrence.vehicle_towed,
             description: occurrence.description,
@@ -101,21 +101,11 @@ export default function AllOrderOccurences({auth, occurrences, flash}) {
             maxWidth: 100,
             renderCell: (params) => (
                 <Link
-                    key={params.value}
-                    href={route('drivers.showEdit', params.value)}
+                    key={params.value.user_id}
+                    href={route('drivers.showEdit', params.value.user_id)}
+                    className='text-blue-500'
                 >
-                    <Button
-                        variant="outlined"
-                        sx={{
-                            maxWidth: '30px',
-                            maxHeight: '30px',
-                            minWidth: '30px',
-                            minHeight: '30px',
-                            margin: '0px 4px'
-                        }}
-                    >
-                        {params.value}
-                    </Button>
+                        {params.value.name}
                 </Link>
             )
         },
@@ -126,21 +116,11 @@ export default function AllOrderOccurences({auth, occurrences, flash}) {
             maxWidth: 100,
             renderCell: (params) => (
                 <Link
-                    key={params.value}
-                    href={route('vehicles.showEdit', params.value)}
+                    key={params.value.id}
+                    href={route('vehicles.showEdit', params.value.id)}
+                    className='text-blue-500'
                 >
-                    <Button
-                        variant="outlined"
-                        sx={{
-                            maxWidth: '30px',
-                            maxHeight: '30px',
-                            minWidth: '30px',
-                            minHeight: '30px',
-                            margin: '0px 4px'
-                        }}
-                    >
-                        {params.value}
-                    </Button>
+                        {params.value.license_plate}
                 </Link>
             )
         },
@@ -205,7 +185,7 @@ export default function AllOrderOccurences({auth, occurrences, flash}) {
                         </a>
                     </Button>
 
-                    <Table data={orderOccurrencesInfo} columnsLabel={orderOccurrencesLabels} editAction={'orderOccurrences.showEdit'} deleteAction={'orderOccurrences.delete'} dataId={'id'}/>
+                    {/* <Table data={orderOccurrencesInfo} columnsLabel={orderOccurrencesLabels} editAction={'orderOccurrences.showEdit'} deleteAction={'orderOccurrences.delete'} dataId={'id'}/> */}
                 
                     <CustomDataGrid
                         rows={orderOccurrencesInfo}


### PR DESCRIPTION
Defined multiple gates for authorizing access to multiple resources, based on the "user_type"

**Notes:** 
* This is not the best way to ensure only certain users can access certain resources, however this was one of the quickest ways to do so, without major changes.
* A lot of gates were created, where some are very similar, as in only `Administrador` (Admin) and `Gestor` (Manager) can access them. This could be simplified by creating policies and binding them to the `User` model, but would require refactoring how user roles are being handled.

## Alternatives
* Creating the same pages with slight differences, within different namespaces for each role. This would take a lot of time to refactor the current project. 
* Change how roles are handled via introducing a new table in the database, for example:
```
id  | name
---+------------
 1  | Admin
 2  | Manager
 3  | Technician
 4  | Driver
```
And introducing a pivot table to "bind" each user to it's role
```
user_id | role_id
--------+--------
   1    |    1
   2    |    4
```
Introduces some complexity initially but is more flexible and scalable.

## Sugestion:
Using Laravel Gates with Policies and introducing a new table for roles, would probably be most beneficial and allow for more flexibility and scalability as the project "grows".