### PR TITLE
Feat/users

### DIFF
--- a/laravel/app/Http/Controllers/AdminController.php
+++ b/laravel/app/Http/Controllers/AdminController.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\Roles;
+use App\Helpers\ErrorMessagesHelper;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
+use Inertia\Inertia;
+use Illuminate\Validation\Rule;
+
+class AdminController extends Controller
+{
+    public function index()
+    {
+        if(!Gate::allows('view-admin')) {
+            abort(403);
+        }
+
+        Log::channel('user')->info('User accessed admins page', [
+            'auth_user_id' => $this->loggedInUserId ?? null,
+        ]);
+
+        $admins = User::where('user_type', Roles::ADMIN->value)->get();
+
+        return Inertia::render('Admins/AllAdmins', [
+            'flash' => [
+                'message' => session('message'),
+                'error' => session('error'),
+            ],
+            'admins' => $admins,
+        ]);
+    }
+
+    public function showCreateAdminForm()
+    {
+        if(!Gate::allows('create-admin')) {
+            abort(403);
+        }
+
+        Log::channel('user')->info('User accessed admin creation page', [
+            'auth_user_id' => $this->loggedInUserId ?? null,
+        ]);
+
+        $users = User::where('user_type', Roles::NONE->value)->get();
+
+        return Inertia::render('Admins/NewAdmin', [
+            'flash' => [
+                'message' => session('message'),
+                'error' => session('error'),
+            ],
+            'users' => $users,
+        ]);
+    }
+
+    public function createAdmin(Request $request)
+    {
+        if(!Gate::allows('create-admin')) {
+            abort(403);
+        }
+
+        // Load custom error messages from helper
+        $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
+
+        $incomingFields = $request->validate([
+            'id' => [
+                'required', 
+                'exists:users,id',
+                
+                function ($attribute, $value, $fail) use ($request) {
+                    $user = User::find($value);
+        
+                    if ($user && $user->user_type != 'Nenhum') {
+                        $fail('Somente utilizadores de tipo "Nenhum" podem ser convertidos em Administradores');
+                    }
+                },
+
+            ],
+        ], $customErrorMessages);
+
+        $user = User::find($incomingFields['id']);
+
+        try {
+            $user->update([
+                'user_type' => Roles::ADMIN->value,
+            ]);
+
+            Log::channel('user')->info('User created a admin', [
+                'auth_user_id' => $this->loggedInUserId ?? null,
+                'admin_id' => $user->id ?? null,
+            ]);
+
+            return redirect()->route('admins.index')->with('message', 'Administrador/a com id ' . $user->id . ' criado/a com sucesso!');
+        
+        } catch (\Exception $e) {
+            Log::channel('usererror')->error('Error creating admin', [
+                'user_id' => $incomingFields['user_id'] ?? null,
+                'exception' => $e->getMessage(),
+                'stack_trace' => $e->getTraceAsString(),
+            ]);
+
+            return redirect()->route('admins.index')->with('error', 'Houve um problema ao adicionar o utilizador com id ' . $user->id . ' à lista de administradores. Tente novamente.');
+        }
+    }
+
+    public function showEditAdminForm(User $user)
+    {
+        if(!Gate::allows('edit-admin')) {
+            abort(403);
+        }
+
+        Log::channel('user')->info('User accessed admin edit page', [
+            'auth_user_id' => $this->loggedInUserId ?? null,
+            'admin_id' => $user->id ?? null,
+        ]);
+
+        return Inertia::render('Admins/EditAdmin', [
+            'flash' => [
+                'message' => session('message'),
+                'error' => session('error'),
+            ],
+            'admin' => $user,
+        ]);
+    }
+
+    public function editAdmin(User $user, Request $request)
+    {
+        if(!Gate::allows('edit-admin')) {
+            abort(403);
+        }
+
+        // Load custom error messages from helper
+        $customErrorMessages = ErrorMessagesHelper::getErrorMessages();
+        
+        $incomingFields = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'lowercase'],
+            'phone' => ['required', 'numeric', 'regex:/^[0-9]{9,15}$/'],
+            'status' => ['required', Rule::in(['Disponível', 'Indisponível', 'Em Serviço', 'Escondido'])],
+        ], $customErrorMessages);
+        
+        $incomingFields['name'] = strip_tags($incomingFields['name']);
+        $incomingFields['email'] = strip_tags($incomingFields['email']);
+
+        try {
+            $user->update([
+                'name' => $incomingFields['name'],
+                'email' => $incomingFields['email'],
+                'phone' => $incomingFields['phone'],
+                'status' => $incomingFields['status'],
+            ]);
+
+            Log::channel('user')->info('User edited an admin', [
+                'auth_user_id' => $this->loggedInUserId ?? null,
+                'admin_id' => $user->id ?? null,
+            ]);
+
+            return redirect()->route('admins.index')->with('message', 'Dados do/a administrador/a com id ' . $user->id . ' atualizados com sucesso!');
+            
+        } catch (\Exception $e) {
+            Log::channel('usererror')->error('Error editing admin', context: [
+                'route_id' => $user->id ?? null,
+                'exception' => $e->getMessage(),
+                'stack_trace' => $e->getTraceAsString(),
+            ]);
+
+            return redirect()->route('admins.index')->with('error', 'Houve um problema ao atualizar os dados do administrador com id ' . $user->id . '. Tente novamente.');
+        }
+    }
+
+    public function deleteAdmin($id)
+    {
+        if(!Gate::allows('delete-admin')) {
+            abort(403);
+        }
+
+        try {
+            $user = User::findOrFail($id);
+            $user->update([
+                'user_type' => Roles::NONE->value,
+            ]);
+
+            Log::channel('user')->info('User deleted an admin', [
+                'auth_user_id' => $this->loggedInUserId ?? null,
+                'admin_id' => $id ?? null,
+            ]);
+
+            return redirect()->route('admins.index')->with('message', 'Utilizador com id ' . $id . ' retirado da lista de administradores com sucesso!');
+
+        } catch (\Exception $e) {
+            Log::channel('usererror')->error('Error deleting admin', [
+                'route_id' => $id ?? null,
+                'exception' => $e->getMessage(),
+                'stack_trace' => $e->getTraceAsString(),
+            ]);
+
+            return redirect()->route('admins.index')->with('error', 'Houve um problema ao retirar o utilizador com id ' . $id . ' da lista de administradores. Tente novamente.');
+        }
+    }
+}

--- a/laravel/app/Http/Controllers/TechnicianController.php
+++ b/laravel/app/Http/Controllers/TechnicianController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\Roles;
 use App\Models\User;
 use Inertia\Inertia;
 use Illuminate\Http\Request;
@@ -23,7 +24,7 @@ class TechnicianController extends Controller
         ]);
 
         // Retrieve all technicians with their related kids, including the pivot priority
-        $technicians = User::where('user_type', 'Técnico')->get();
+        $technicians = User::where('user_type', Roles::TECHNICIAN->value)->get();
 
         return Inertia::render('Technicians/AllTechnicians', [
             'flash' => [
@@ -44,7 +45,7 @@ class TechnicianController extends Controller
             'auth_user_id' => $this->loggedInUserId ?? null,
         ]);
 
-        $users = User::where('user_type', 'Nenhum')->get();
+        $users = User::where('user_type', Roles::NONE->value)->get();
 
         return Inertia::render('Technicians/NewTechnician', [
             'flash' => [
@@ -72,7 +73,7 @@ class TechnicianController extends Controller
                 function ($attribute, $value, $fail) use ($request) {
                     $user = User::find($value);
         
-                    if ($user && $user->user_type != 'Nenhum') {
+                    if ($user && $user->user_type != Roles::NONE->value) {
                         $fail('Somente utilizadores de tipo "Nenhum" podem ser convertidos em técnicos');
                     }
                 },
@@ -84,7 +85,7 @@ class TechnicianController extends Controller
 
         try {
             $user->update([
-                'user_type' => "Técnico",
+                'user_type' => Roles::TECHNICIAN->value,
             ]);
 
             Log::channel('user')->info('User created a technician', [
@@ -179,7 +180,7 @@ class TechnicianController extends Controller
         try {
             $user = User::findOrFail($id);
             $user->update([
-                'user_type' => "Nenhum",
+                'user_type' => Roles::NONE->value,
             ]);
 
             Log::channel('user')->info('User deleted a technician', [

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -412,5 +412,30 @@ class AppServiceProvider extends ServiceProvider
                 ? Response::allow()
                 : Response::denyWithStatus(403);
         });
+
+        // Admins
+        Gate::define('view-admin', function (User $user) {
+            return $user->isAdmin()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('create-admin', function (User $user) {
+            return $user->isAdmin()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('edit-admin', function (User $user) {
+            return $user->isAdmin()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('delete-admin', function (User $user) {
+            return $user->isAdmin()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
     }
 }

--- a/laravel/database/factories/AdminFactory.php
+++ b/laravel/database/factories/AdminFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\Roles;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Model>
+ */
+class AdminFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    protected $model = User::class;
+    protected static ?string $password;
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'email' => fake()->unique()->safeEmail(),
+            'email_verified_at' => now(),
+            'password' => static::$password ??= Hash::make('password'),
+            'remember_token' => Str::random(10),
+            'phone' => rand(910000000, 999999999),
+            'user_type' => Roles::ADMIN->value,
+        ];
+    }
+}

--- a/laravel/resources/js/Layouts/AuthenticatedLayout.jsx
+++ b/laravel/resources/js/Layouts/AuthenticatedLayout.jsx
@@ -117,9 +117,9 @@ export default function Authenticated({ user, header, children }) {
                                                 <Dropdown.Link  href={route('drivers.index')} active={route().current('drivers.index')}>Condutores</Dropdown.Link>
                                                 <Dropdown.Link  href={route('technicians.index')} active={route().current('technicians.index')}>Técnicos</Dropdown.Link>
                                                 <Dropdown.Link  href={route('managers.index')} active={route().current('managers.index')}>Gestores</Dropdown.Link>
+                                                <Dropdown.Link  href={route('admins.index')} active={route().current('admins.index')}>Administradores</Dropdown.Link>
 
                                                 {/* TODO: Links para: */}
-                                                {/* 2º) ADMINISTRADORES */}
                                                 {/* 5º) POR ATRIBUIR */}
                                             </Dropdown.Content>
                                         </Dropdown>

--- a/laravel/resources/js/Pages/Admins/AllAdmins.jsx
+++ b/laravel/resources/js/Pages/Admins/AllAdmins.jsx
@@ -1,0 +1,113 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import AddIcon from '@mui/icons-material/Add';
+import { Head } from '@inertiajs/react';
+import { Button, Snackbar, Alert, Chip  } from '@mui/material';
+import { useEffect, useState } from 'react';
+import CustomDataGrid from '@/Components/CustomDataGrid';
+
+function renderStatus(status) {
+    const colors = {
+        'Disponível': 'success',
+        'Em Serviço': 'warning',
+        'Indisponível': 'error',
+        'Escondido': 'default',
+    };
+  
+    return <Chip label={status} color={colors[status]} variant="outlined" size="small" />;
+}
+
+export default function AllAdmins({ auth, admins, flash, permissions }) {
+
+    const [openSnackbar, setOpenSnackbar] = useState(false);
+    const [snackbarMessage, setSnackbarMessage] = useState('');
+    const [snackbarSeverity, setSnackbarSeverity] = useState('success');
+
+    useEffect(() => {
+        if (flash.message || flash.error) {
+            setSnackbarMessage(flash.message || flash.error);
+            setSnackbarSeverity(flash.error ? 'error' : 'success');
+            setOpenSnackbar(true);
+        }
+    }, [flash]);
+    
+    const adminsInfo = admins.map((admins) => {   
+        return {
+            id: admins.id,
+            name: admins.name,
+            email: admins.email,
+            phone: admins.phone,
+            status: admins.status,
+        }
+    })
+
+    const adminsColumns = [
+        {
+            field: 'id',
+            headerName: 'ID',
+            flex: 1,
+            maxWidth: 60,
+            hideable: false
+        },
+        {
+            field: 'name',
+            headerName: 'Nome',
+            flex: 1,
+        },
+        {
+            field: 'email',
+            headerName: 'Email',
+            flex: 1,
+        },
+        {
+            field: 'phone',
+            headerName: 'Número de Telefone',
+            flex: 1,
+        },
+        {
+            field: 'status',
+            headerName: 'Estado',
+            flex: 1,
+            renderCell: (params) => (renderStatus(params.value))
+        },
+    ]
+    
+    return (
+        <AuthenticatedLayout
+            user={auth.user}
+            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">Administradores</h2>}
+        >
+
+            <Head title="Técnicos" />
+        
+            <div className="py-12 px-6">
+                <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <Button href={route('admins.showCreate')} className="font-medium text-blue-600 dark:text-blue-500 hover:underline">
+                        <AddIcon />
+                        <a className="font-medium text-sky-600 dark:text-sky-500 hover:underline">
+                            Novo Administrador
+                        </a>
+                    </Button>
+                
+                    <CustomDataGrid 
+                        rows={adminsInfo}
+                        columns={adminsColumns}
+                        editAction="admins.showEdit" 
+                        deleteAction="admins.delete"
+                        permissions={permissions}
+                    />
+                </div>
+            </div>
+
+            <Snackbar 
+                open={openSnackbar} 
+                autoHideDuration={3000}
+                onClose={() => setOpenSnackbar(false)}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+            >
+                <Alert variant='filled' onClose={() => setOpenSnackbar(false)} severity={snackbarSeverity} sx={{ width: '100%' }}>
+                    {snackbarMessage}
+                </Alert>
+            </Snackbar>
+        </AuthenticatedLayout>
+    );
+}

--- a/laravel/resources/js/Pages/Admins/EditAdmin.jsx
+++ b/laravel/resources/js/Pages/Admins/EditAdmin.jsx
@@ -1,0 +1,199 @@
+import React, { useState, useEffect } from 'react';
+import { Snackbar, Alert, FormControl, Button, TextField, FormControlLabel, Radio, RadioGroup, FormLabel } from '@mui/material';
+import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout";
+import { Head, useForm } from '@inertiajs/react';
+
+export default function EditTechnician({ auth, admin, flash}) {
+    
+    const [openSnackbar, setOpenSnackbar] = useState(false);
+    const [snackbarMessage, setSnackbarMessage] = useState('');
+    const [snackbarSeverity, setSnackbarSeverity] = useState('success');
+    const [isEditMode, setisEditMode] = useState(false)
+
+    useEffect(() => {
+        if (flash.message || flash.error) {
+            setSnackbarMessage(flash.message || flash.error);
+            setSnackbarSeverity(flash.error ? 'error' : 'success');
+            setOpenSnackbar(true);
+        }
+    }, [flash]);
+
+    const initialData = {
+        id: admin.id,
+        name: admin.name,
+        email: admin.email,
+        phone: admin.phone,
+        status: admin.status,
+    }
+
+    const { data, setData, put, errors, processing } = useForm({...initialData});
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+    const toggleEdit = () => {
+        if (isEditMode) {
+            setData({ ...initialData });
+        }
+        setisEditMode(!isEditMode);
+    }
+
+    const handleChange = (e) => {
+        const { name, value, type, checked } = e.target;
+        setData(name, type === 'radio' ? value : value);
+    };
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        put(route('admins.edit', admin.id), {
+            onError: (error) => {
+                console.error(error);
+            }
+        });
+    };
+
+    return(
+        <AuthenticatedLayout
+            user={auth.user}
+            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">Administrador #{admin.id}</h2>}
+        >
+
+            {<Head title='Editar Administrador' />}
+
+            <div className="py-12">
+                <div className="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+                    <div className="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+
+                        <form onSubmit={handleSubmit}>
+                            <input type="hidden" name="_token" value={csrfToken} />
+
+                            { isEditMode === false ? 
+                                (<div className='mb-4'>
+                                    <Button
+                                    variant="contained"
+                                    color="primary"
+                                    disabled={processing}
+                                    onClick={toggleEdit}
+                                >
+                                    Editar
+                                    </Button>
+                                </div>) : 
+
+                            (<div className='mb-4 space-x-4'>
+                                <Button 
+                                    variant="outlined"
+                                    color="error"
+                                    disabled={processing}
+                                    onClick={toggleEdit}
+                                >
+                                    Cancelar Edição
+                                </Button>
+                                <Button
+                                    type="submit"
+                                    variant="outlined"
+                                    color="primary"
+                                    disabled={processing}
+                                >
+                                    Submeter
+                                </Button>
+                            </div>)}
+
+                            {/* Name Field */}
+                            <FormControl fullWidth margin="normal">
+                                <TextField
+                                    label="Nome"
+                                    id="name"
+                                    name="name"
+                                    value={data.name}
+                                    onChange={(e) => setData('name', e.target.value)}
+                                    className={!isEditMode ? 'read-only-field' : ''}
+                                    disabled={!isEditMode}
+                                    error={errors.name ? true : false}
+                                    helperText={errors.name && errors.name}
+                                    fullWidth
+                                />
+                            </FormControl>
+
+                            {/* Email Field */}
+                            <FormControl fullWidth margin="normal">
+                                <TextField
+                                    label="Email"
+                                    id="email"
+                                    name="email"
+                                    type="email"
+                                    value={data.email}
+                                    onChange={(e) => setData('email', e.target.value)}
+                                    className={!isEditMode ? 'read-only-field' : ''}
+                                    disabled={!isEditMode}
+                                    error={errors.email ? true : false}
+                                    helperText={errors.email && errors.email}
+                                    fullWidth
+                                />
+                            </FormControl>
+
+                            {/* Phone Field */}
+                            <FormControl fullWidth margin="normal">
+                                <TextField
+                                    label="Número de telemóvel"
+                                    id="phone"
+                                    name="phone"
+                                    type="tel"
+                                    value={data.phone}
+                                    onChange={(e) => setData('phone', e.target.value)}
+                                    className={!isEditMode ? 'read-only-field' : ''}
+                                    disabled={!isEditMode}
+                                    error={errors.phone ? true : false}
+                                    helperText={errors.phone && errors.phone}
+                                    fullWidth
+                                />
+                            </FormControl>
+
+                            <FormControl component="fieldset" margin="normal" disabled={!isEditMode}>
+                                <FormLabel component="legend">Disponível?</FormLabel>
+                                <RadioGroup
+                                    name="status"
+                                    value={data.status}
+                                    onChange={handleChange}
+                                    row
+                                >
+                                    <FormControlLabel
+                                        value="Disponível"
+                                        control={<Radio />}
+                                        label="Disponível"
+                                    />
+                                    <FormControlLabel
+                                        value="Indisponível"
+                                        control={<Radio />}
+                                        label="Indisponível"
+                                    />
+                                    <FormControlLabel
+                                        value="Em Serviço"
+                                        control={<Radio />}
+                                        label="Em Serviço"
+                                    />
+                                    <FormControlLabel
+                                        value="Escondido"
+                                        control={<Radio />}
+                                        label="Escondido"
+                                    />
+                                </RadioGroup>
+                            </FormControl>
+                            <br/>
+                        </form>
+                       
+                        <Snackbar 
+                                open={openSnackbar} 
+                                autoHideDuration={3000}
+                                onClose={() => setOpenSnackbar(false)}
+                                anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+                            >
+                                <Alert variant='filled' onClose={() => setOpenSnackbar(false)} severity={snackbarSeverity} sx={{ width: '100%' }}>
+                                    {snackbarMessage}
+                                </Alert>
+                        </Snackbar>
+                    </div>
+                </div>
+            </div>
+
+        </AuthenticatedLayout>
+    )
+}

--- a/laravel/resources/js/Pages/Admins/NewAdmin.jsx
+++ b/laravel/resources/js/Pages/Admins/NewAdmin.jsx
@@ -1,0 +1,95 @@
+import InputError from '@/Components/InputError';
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, useForm } from '@inertiajs/react';
+import { Autocomplete, TextField, Button, Snackbar, Alert } from '@mui/material';
+import { useState, useEffect } from 'react';
+
+export default function NewAdmin({ auth, users, flash }) {
+
+    const [openSnackbar, setOpenSnackbar] = useState(false);
+    const [snackbarMessage, setSnackbarMessage] = useState('');
+    const [snackbarSeverity, setSnackbarSeverity] = useState('success');
+
+    useEffect(() => {
+        if (flash.message || flash.error) {
+            setSnackbarMessage(flash.message || flash.error);
+            setSnackbarSeverity(flash.error ? 'error' : 'success');
+            setOpenSnackbar(true);
+        }
+    }, [flash]);
+
+    const { setData, post, errors } = useForm({
+        id: '',
+    });
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+    const userList = users.map((user) => {
+        return { value: user.id, label: `#${user.id} - ${user.name}`, }
+    })
+
+    const handleUserChange = (event, newValue) => {
+        setData('id', newValue?.value.toString() || ''); // Update form data with the selected user's ID
+    };
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        post(route('admins.create'));
+    };
+
+    return (
+        <AuthenticatedLayout
+            user={auth.user}
+            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">Novo Administrador</h2>}
+        >
+
+            {<Head title='Criar Administrador' />}
+
+            <div className='py-12'>
+                <div className="max-w-7xl mx-auto my-4 sm:px-6 lg:px-8">
+                    <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                        <div className='p-6'>
+
+                            <h2>Criar administrador a partir de utilizador existente</h2>
+
+                            <form onSubmit={handleSubmit}>
+                                <input type="hidden" name="_token" value={csrfToken} />
+                                <p>Selecione o utilizador</p>
+
+                                <Autocomplete
+                                    id='user-combo-box'
+                                    options={userList}
+                                    getOptionLabel={(option) => option.label}
+                                    onChange={handleUserChange}
+                                    renderInput={(params) => <TextField {...params} label="Utilizador" />}
+                                    sx={{ width: 500 }}
+                                />
+                                {errors.id && <InputError message={errors.id} />}
+
+                                <br />
+
+                                <Button variant="outlined" type="submit" value="Submit">
+                                    Submeter
+                                </Button>
+                            </form>
+
+
+                            <Snackbar
+                                open={openSnackbar}
+                                autoHideDuration={3000}
+                                onClose={() => setOpenSnackbar(false)}
+                                anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+                            >
+                                <Alert variant='filled' onClose={() => setOpenSnackbar(false)} severity={snackbarSeverity} sx={{ width: '100%' }}>
+                                    {snackbarMessage}
+                                </Alert>
+                            </Snackbar>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </AuthenticatedLayout>
+    )
+
+}

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\AdminController;
 use App\Http\Controllers\BackupController;
 use Inertia\Inertia;
 use Illuminate\Support\Facades\Route;
@@ -219,6 +220,14 @@ Route::middleware('auth')->group(function () {
     Route::get('/vehicle/refuelRequests/edit/{vehicleRefuelRequest}', [VehicleRefuelRequestController::class, 'showEditVehicleRefuelRequestForm'])->name('vehicleRefuelRequests.showEdit');
     Route::put('/vehicle/refuelRequests/edit/{vehicleRefuelRequest}', [VehicleRefuelRequestController::class, 'editVehicleRefuelRequest'])->name('vehicleRefuelRequests.edit');
     Route::delete('/vehicle/refuelRequests/delete/{vehicleRefuelRequest}', [VehicleRefuelRequestController::class, 'deleteVehicleRefuelRequest'])->name('vehicleRefuelRequests.delete');
+
+    //ADMINS (USER MODEL WITH Administrador USER_TYPE)
+    Route::get('/users/admins', [AdminController::class, 'index'])->name('admins.index');
+    Route::get('/users/admins/create', [AdminController::class, 'showCreateAdminForm'])->name('admins.showCreate');
+    Route::post('/users/admins/create', [AdminController::class, 'createAdmin'])->name('admins.create');
+    Route::get('/users/admins/edit/{user}', [AdminController::class, 'showEditAdminForm'])->name('admins.showEdit');
+    Route::put('/users/admins/edit/{user}', [AdminController::class, 'editAdmin'])->name('admins.edit');
+    Route::delete('/users/admins/delete/{user}', [AdminController::class, 'deleteAdmin'])->name('admins.delete');
 });
 
 require __DIR__.'/auth.php';

--- a/laravel/tests/Feature/Users/AdminTest.php
+++ b/laravel/tests/Feature/Users/AdminTest.php
@@ -115,7 +115,7 @@ class AdminTest extends TestCase
             $response->assertForbidden();
 
             $this->assertDatabaseMissing('users', [
-                'id' => $user->id,
+                'id' => $newAdmin->id,
                 'user_type' => Roles::ADMIN->value,
             ]);
         }

--- a/laravel/tests/Feature/Users/AdminTest.php
+++ b/laravel/tests/Feature/Users/AdminTest.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\Roles;
+use Database\Factories\AdminFactory;
+use Database\Factories\DriverFactory;
+use Database\Factories\ManagerFactory;
+use Database\Factories\TechnicianFactory;
+use Database\Factories\UserFactory;
+use Tests\TestCase;
+use App\Models\User;
+use Illuminate\Support\Arr;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class AdminTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create(['user_type' => Roles::ADMIN->value]);
+    }
+
+    public function test_admins_page_is_displayed(): void
+    {
+        $response = $this
+            ->actingAs($this->user)
+            ->get(route('admins.index'));
+
+        $response->assertOk();
+    }
+
+    public function test_admins_page_is_not_displayed_due_permissions(): void
+    {
+        $this->assertForbiddenForNonAdmins('admins.index');
+    }
+
+    public function test_admin_creation_page_is_displayed(): void
+    {
+        $response = $this
+            ->actingAs($this->user)
+            ->get(route('admins.showCreate'));
+
+        $response->assertOk();
+    }
+
+    public function test_admin_creation_page_is_not_displayed_due_permissions(): void
+    {
+        $this->assertForbiddenForNonAdmins('admins.showCreate');
+    }
+
+    public function test_admin_edit_page_is_displayed(): void
+    {
+        $admin = AdminFactory::new()->create();
+
+        $response = $this
+            ->actingAs($this->user)
+            ->get(route('admins.showEdit', $admin->id));
+
+        $response->assertOk();
+    }
+
+    public function test_admin_edit_page_is_not_displayed_due_permissions(): void
+    {
+        $admin = AdminFactory::new()->create();
+        $this->assertForbiddenForNonAdmins('admins.showEdit', $admin->id);
+    }
+
+    public function test_user_can_create_an_admin(): void
+    {
+        $user = User::factory()->create();
+
+        $adminData = [
+            'id' => $user->id,
+            'user_type' => Roles::NONE->value
+        ];
+
+        $response = $this
+            ->actingAs($this->user)
+            ->post(route('admins.create'), $adminData);
+
+        $response
+            ->assertSessionHasNoErrors()
+            ->assertRedirect(route('admins.index'));
+
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'user_type' => Roles::ADMIN->value,
+        ]);
+    }
+
+    public function test_user_cannot_create_an_admin_due_permissions(): void
+    {
+        $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
+        $manager = UserFactory::new()->create(['user_type' => Roles::MANAGER->value]);
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+
+        $users = [$technician, $manager, $driver];
+
+        foreach ($users as $user) {
+            $adminData = ['id' => $user->id, 'user_type' => Roles::NONE->value];
+
+            $response = $this
+                ->actingAs($user)
+                ->post(route('admins.create'), $adminData);
+
+            $response->assertForbidden();
+
+            $this->assertDatabaseMissing('users', [
+                'id' => $user->id,
+                'user_type' => Roles::ADMIN->value,
+            ]);
+        }
+    }
+
+    public function test_create_admins_fails_on_user_type_is_not_none(): void
+    {
+        $user = User::factory()->create([
+            'user_type' => Roles::MANAGER->value,
+        ]);
+
+        $adminData = [
+            'id' => $user->id,
+        ];
+
+        $response = $this
+            ->actingAs($this->user)
+            ->post(route('admins.create'), $adminData);
+
+        $response->assertSessionHasErrors(['id']);
+
+        $this->assertDatabaseMissing('users', [
+            'id' => $user->id,
+            'user_type' => Roles::ADMIN->value,
+        ]);
+    }
+
+    public function test_user_can_edit_an_admin(): void
+    {
+        $admin = AdminFactory::new()->create();
+
+        $updatedData = [
+            'name' => fake()->name(),
+            'phone' => rand(910000000, 999999999),
+            'email' => fake()->unique()->safeEmail(),
+            'status' => Arr::random(['Disponível', 'Indisponível', 'Em Serviço', 'Escondido']),
+        ];
+
+        $response = $this
+            ->actingAs($this->user)
+            ->put(route('admins.edit', $admin->id), $updatedData);
+
+        $response
+            ->assertSessionHasNoErrors()
+            ->assertRedirect(route('admins.index'));
+
+            $this->assertDatabaseHas('users', array_merge(['id' => $admin->id], $updatedData));
+    }
+
+    public function test_user_cannot_edit_an_admin_due_permissions(): void
+    {
+        $admin = AdminFactory::new()->create();
+
+        $updatedData = [
+            'name' => fake()->name(),
+            'phone' => rand(910000000, 999999999),
+            'email' => fake()->unique()->safeEmail(),
+            'status' => Arr::random(['Disponível', 'Indisponível', 'Em Serviço', 'Escondido']),
+        ];
+
+        $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
+        $manager = UserFactory::new()->create(['user_type' => Roles::MANAGER->value]);
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+
+        $users = [$technician, $manager, $driver];
+
+        foreach ($users as $user) {
+            $response = $this
+                ->actingAs($user)
+                ->put(route('admins.edit', $admin->id), $updatedData);
+
+            $response->assertForbidden();
+
+            $this->assertDatabaseMissing('users', $updatedData);
+        }
+    }
+
+    public function test_user_can_delete_an_admin(): void
+    {
+        $admin = AdminFactory::new()->create();
+
+        $this->assertDatabaseHas('users', [
+            'id' => $admin->id,
+            'user_type' => Roles::ADMIN->value
+        ]);
+
+        $response = $this
+            ->actingAs($this->user)
+            ->delete(route('admins.delete', $admin->id));
+
+        $response
+            ->assertSessionHasNoErrors()
+            ->assertRedirect(route('admins.index'));
+
+        $this->assertDatabaseHas('users', [
+            'id' => $admin->id,
+            'user_type' => Roles::NONE->value
+        ]);
+    }
+
+    public function test_user_cannot_delete_an_admin_due_permissions(): void
+    {
+        $admin = AdminFactory::new()->create();
+
+        $this->assertDatabaseHas('users', [
+            'id' => $admin->id,
+            'user_type' => Roles::ADMIN->value
+        ]);
+
+        $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
+        $manager = UserFactory::new()->create(['user_type' => Roles::MANAGER->value]);
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+
+        $users = [$technician, $manager, $driver];
+
+        foreach ($users as $user) {
+            $response = $this
+                ->actingAs($user)
+                ->delete(route('admins.delete', $admin->id));
+
+            $response->assertForbidden();
+
+            $this->assertDatabaseMissing('users', [
+                'id' => $admin->id,
+                'user_type' => Roles::NONE->value
+            ]);
+        }
+    }
+
+    public function test_admin_creation_handles_exception()
+    {
+        $user = User::factory()->create();
+
+        $data = [
+            'id' => $user->id,
+        ];
+
+        // Mock the User model to throw an exception
+        $this->mock(User::class, function ($mock) {
+            $mock->shouldReceive('create')
+                ->andThrow(new \Exception('Database error'));
+        });
+
+        // Act: Send a POST request to the create admin route
+        $response = $this
+            ->actingAs($this->user)
+            ->post(route('admins.create'), $data);
+
+        // Assert: Check if the catch block was executed
+        $response->assertRedirect(route('admins.index')); // Ensure it redirects back to the form
+    }
+
+    /**
+     * Auxiliar method to verify if non-admin users cannot access some pages
+     * @param string $route
+     * @param mixed $id
+     * @return void
+     */
+    private function assertForbiddenForNonAdmins(string $route, ?int $id = null): void
+    {
+        $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
+        $manager = UserFactory::new()->create(['user_type' => Roles::MANAGER->value]);
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+
+        $users = [$technician, $manager, $driver];
+
+        foreach ($users as $user) {
+            $response = $this
+                ->actingAs($user)
+                ->get(route($route, $id ? [$id] : []));
+
+            $response->assertForbidden();
+        }
+    }
+}

--- a/laravel/tests/Feature/Users/AdminTest.php
+++ b/laravel/tests/Feature/Users/AdminTest.php
@@ -4,9 +4,6 @@ namespace Tests\Feature;
 
 use App\Enums\Roles;
 use Database\Factories\AdminFactory;
-use Database\Factories\DriverFactory;
-use Database\Factories\ManagerFactory;
-use Database\Factories\TechnicianFactory;
 use Database\Factories\UserFactory;
 use Tests\TestCase;
 use App\Models\User;
@@ -99,11 +96,17 @@ class AdminTest extends TestCase
         $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
         $manager = UserFactory::new()->create(['user_type' => Roles::MANAGER->value]);
         $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
 
-        $users = [$technician, $manager, $driver];
+        $users = [$technician, $manager, $driver, $none];
 
         foreach ($users as $user) {
-            $adminData = ['id' => $user->id, 'user_type' => Roles::NONE->value];
+            $newAdmin = User::factory()->create();
+
+            $adminData = [
+                'id' => $newAdmin->id,
+                'user_type' => Roles::NONE->value
+            ];
 
             $response = $this
                 ->actingAs($user)
@@ -159,7 +162,7 @@ class AdminTest extends TestCase
             ->assertSessionHasNoErrors()
             ->assertRedirect(route('admins.index'));
 
-            $this->assertDatabaseHas('users', array_merge(['id' => $admin->id], $updatedData));
+        $this->assertDatabaseHas('users', array_merge(['id' => $admin->id], $updatedData));
     }
 
     public function test_user_cannot_edit_an_admin_due_permissions(): void
@@ -176,8 +179,9 @@ class AdminTest extends TestCase
         $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
         $manager = UserFactory::new()->create(['user_type' => Roles::MANAGER->value]);
         $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
 
-        $users = [$technician, $manager, $driver];
+        $users = [$technician, $manager, $driver, $none];
 
         foreach ($users as $user) {
             $response = $this
@@ -225,8 +229,9 @@ class AdminTest extends TestCase
         $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
         $manager = UserFactory::new()->create(['user_type' => Roles::MANAGER->value]);
         $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
 
-        $users = [$technician, $manager, $driver];
+        $users = [$technician, $manager, $driver, $none];
 
         foreach ($users as $user) {
             $response = $this
@@ -276,8 +281,9 @@ class AdminTest extends TestCase
         $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
         $manager = UserFactory::new()->create(['user_type' => Roles::MANAGER->value]);
         $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
 
-        $users = [$technician, $manager, $driver];
+        $users = [$technician, $manager, $driver, $none];
 
         foreach ($users as $user) {
             $response = $this

--- a/laravel/tests/Feature/Users/DriverTest.php
+++ b/laravel/tests/Feature/Users/DriverTest.php
@@ -26,7 +26,7 @@ class DriverTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create(['user_type' => 'Administrador']);
+        $this->user = User::factory()->create(['user_type' => Roles::ADMIN->value]);
     }
 
     protected function getRandomRegionIdentifier(): string

--- a/laravel/tests/Feature/Users/DriverTest.php
+++ b/laravel/tests/Feature/Users/DriverTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature;
 
+use App\Enums\Roles;
+use Database\Factories\UserFactory;
 use Log;
 use Tests\TestCase;
 use App\Models\User;
@@ -18,7 +20,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 class DriverTest extends TestCase
 {
     use RefreshDatabase;
-    
+
     protected $user;
 
     protected function setUp(): void
@@ -27,7 +29,7 @@ class DriverTest extends TestCase
         $this->user = User::factory()->create(['user_type' => 'Administrador']);
     }
 
-    protected function getRandomRegionIdentifier() :string
+    protected function getRandomRegionIdentifier(): string
     {
         /*
         Aveiro - AV.
@@ -53,7 +55,7 @@ class DriverTest extends TestCase
         Ponta Delgada - A.
         Funchal - M.
         */
-        return Arr::random(['AV','BE','BR','BG','CB','C','E','FA','GD','LE','L','PT','P','SA','SE','VC','VR','VS','AN','H','A','M']);
+        return Arr::random(['AV', 'BE', 'BR', 'BG', 'CB', 'C', 'E', 'FA', 'GD', 'LE', 'L', 'PT', 'P', 'SA', 'SE', 'VC', 'VR', 'VS', 'AN', 'H', 'A', 'M']);
     }
 
     public function test_driver_has_many_orders(): void
@@ -127,6 +129,11 @@ class DriverTest extends TestCase
         $response->assertOk();
     }
 
+    public function test_drivers_page_is_not_displayed_due_permissions(): void
+    {
+        $this->assertForbiddenForNonAdminsAndManagers('drivers.index');
+    }
+
     public function test_driver_creation_page_is_displayed(): void
     {
         $response = $this
@@ -134,6 +141,11 @@ class DriverTest extends TestCase
             ->get(route('drivers.showCreate'));
 
         $response->assertOk();
+    }
+
+    public function test_driver_creation_page_is_not_displayed_due_permissions(): void
+    {
+        $this->assertForbiddenForNonAdminsAndManagers('drivers.showCreate');
     }
 
     public function test_driver_edit_page_is_displayed(): void
@@ -147,11 +159,18 @@ class DriverTest extends TestCase
         $response->assertOk();
     }
 
+    public function test_driver_edit_page_is_not_displayed_due_permissions(): void
+    {
+        $driver = Driver::factory()->create();
+
+        $this->assertForbiddenForNonAdminsAndManagers('drivers.showCreate', $driver->user_id);
+    }
+
     public function test_user_can_create_a_driver(): void
     {
         $heavyLicense = fake()->boolean();
         $heavyLicenseType = $heavyLicense ? Arr::random(['Mercadorias', 'Passageiros']) : null;
-        $childrenTransportationCertified = rand(0,1);
+        $childrenTransportationCertified = rand(0, 1);
         $certificationExpiration = $childrenTransportationCertified ? fake()->date() : null;
 
         $driverData = [
@@ -159,7 +178,7 @@ class DriverTest extends TestCase
             'license_number' => $this->getRandomRegionIdentifier() . '-' . str_pad(rand(0, 999999), 6, '0', STR_PAD_LEFT) . ' ' . rand(0, 9),
             'heavy_license' => $heavyLicense,
             'heavy_license_type' => $heavyLicenseType,
-            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1,5))),
+            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1, 5))),
             'tcc' => $childrenTransportationCertified,
             'tcc_expiration_date' => $certificationExpiration,
         ];
@@ -183,7 +202,49 @@ class DriverTest extends TestCase
         ]);
     }
 
-    public function test_create_driver_fails_on_wrong_license_number_format (): void
+    public function test_user_cannot_create_a_driver_due_permissions(): void
+    {
+        $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
+
+        $users = [$technician, $driver, $none];
+
+        foreach ($users as $user) {
+            $heavyLicense = fake()->boolean();
+            $heavyLicenseType = $heavyLicense ? Arr::random(['Mercadorias', 'Passageiros']) : null;
+            $childrenTransportationCertified = rand(0, 1);
+            $certificationExpiration = $childrenTransportationCertified ? fake()->date() : null;
+
+            $driverData = [
+                'user_id' => User::factory()->create()->id,
+                'license_number' => $this->getRandomRegionIdentifier() . '-' . str_pad(rand(0, 999999), 6, '0', STR_PAD_LEFT) . ' ' . rand(0, 9),
+                'heavy_license' => $heavyLicense,
+                'heavy_license_type' => $heavyLicenseType,
+                'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1, 5))),
+                'tcc' => $childrenTransportationCertified,
+                'tcc_expiration_date' => $certificationExpiration,
+            ];
+
+            $response = $this
+                ->actingAs($user)
+                ->post(route('drivers.create'), $driverData);
+
+            $response->assertForbidden();
+
+            $this->assertDatabaseMissing('drivers', [
+                'user_id' => $driverData['user_id'],
+                'license_number' => $driverData['license_number'],
+                'heavy_license' => $driverData['heavy_license'],
+                'heavy_license_type' => $driverData['heavy_license_type'],
+                'license_expiration_date' => $driverData['license_expiration_date'],
+                'tcc' => $driverData['tcc'],
+                'tcc_expiration_date' => $driverData['tcc_expiration_date'],
+            ]);
+        }
+    }
+
+    public function test_create_driver_fails_on_wrong_license_number_format(): void
     {
         // Invalid region identifier (first letters)
         $driverData_1 = [
@@ -191,7 +252,7 @@ class DriverTest extends TestCase
             'license_number' => 'ZZ' . '-' . str_pad(rand(0, 999999), 6, '0', STR_PAD_LEFT) . ' ' . rand(0, 9),
             'heavy_license' => 1,
             'heavy_license_type' => 'Mercadorias',
-            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1,5))),
+            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1, 5))),
             'tcc' => 0,
         ];
 
@@ -216,7 +277,7 @@ class DriverTest extends TestCase
             'license_number' => $this->getRandomRegionIdentifier() . '-' . rand(0, 99999) . ' ' . rand(0, 9),
             'heavy_license' => 1,
             'heavy_license_type' => 'Mercadorias',
-            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1,5))),
+            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1, 5))),
             'tcc' => 0,
         ];
 
@@ -241,7 +302,7 @@ class DriverTest extends TestCase
             'license_number' => $this->getRandomRegionIdentifier() . '-' . str_pad(rand(0, 999999), 6, '0', STR_PAD_LEFT) . ' ' . chr(rand(65, 90)),
             'heavy_license' => 1,
             'heavy_license_type' => 'Mercadorias',
-            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1,5))),
+            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1, 5))),
             'tcc' => 0,
         ];
 
@@ -266,7 +327,7 @@ class DriverTest extends TestCase
             'license_number' => 'ZZ' . str_pad(rand(0, 999999), 6, '0', STR_PAD_LEFT) . rand(0, 9),
             'heavy_license' => 1,
             'heavy_license_type' => 'Mercadorias',
-            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1,5))),
+            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1, 5))),
             'tcc' => 0,
         ];
 
@@ -291,7 +352,7 @@ class DriverTest extends TestCase
             'license_number' => Driver::factory()->create()->license_number,
             'heavy_license' => 1,
             'heavy_license_type' => 'Mercadorias',
-            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1,5))),
+            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1, 5))),
             'tcc' => 0,
         ];
 
@@ -314,7 +375,12 @@ class DriverTest extends TestCase
     public function test_create_driver_fails_on_user_type_is_not_none(): void
     {
         $user = User::factory()->create([
-            'user_type' => Arr::random(['Técnico', 'Gestor', 'Condutor', 'Administrador']),
+            'user_type' => Arr::random([
+                Roles::TECHNICIAN->value,
+                Roles::MANAGER->value,
+                Roles::DRIVER->value,
+                Roles::ADMIN->value
+            ]),
         ]);
 
         $driverData = [
@@ -322,7 +388,7 @@ class DriverTest extends TestCase
             'license_number' => $this->getRandomRegionIdentifier() . '-' . str_pad(rand(0, 999999), 6, '0', STR_PAD_LEFT) . ' ' . rand(0, 9),
             'heavy_license' => 1,
             'heavy_license_type' => 'Mercadorias',
-            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1,5))),
+            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1, 5))),
             'tcc' => 0,
         ];
 
@@ -344,23 +410,23 @@ class DriverTest extends TestCase
 
     public function test_user_can_edit_a_driver(): void
     {
-        $heavyLicense = rand(0,1);
+        $heavyLicense = rand(0, 1);
         $heavyLicenseType = $heavyLicense ? Arr::random(['Mercadorias', 'Passageiros']) : null;
-        $childrenTransportationCertified = rand(0,1);
+        $childrenTransportationCertified = rand(0, 1);
         $certificationExpiration = $childrenTransportationCertified ? fake()->date() : null;
 
         $driver = Driver::factory()->create([
             'user_id' => User::factory()->create()->id,
             'heavy_license' => $heavyLicense,
             'heavy_license_type' => $heavyLicenseType,
-            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1,5))),
+            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1, 5))),
             'tcc' => $childrenTransportationCertified,
             'tcc_expiration_date' => $certificationExpiration,
         ]);
-    
-        $newHeavyLicense = rand(0,1);
+
+        $newHeavyLicense = rand(0, 1);
         $newHeavyLicenseType = $newHeavyLicense ? Arr::random(['Mercadorias', 'Passageiros']) : null;
-        $newChildrenTransportationCertified = rand(0,1);
+        $newChildrenTransportationCertified = rand(0, 1);
         $newCertificationExpiration = $newChildrenTransportationCertified ? fake()->date() : null;
 
         $updatedData = [
@@ -372,11 +438,11 @@ class DriverTest extends TestCase
             'license_number' => $this->getRandomRegionIdentifier() . '-' . str_pad(rand(0, 999999), 6, '0', STR_PAD_LEFT) . ' ' . rand(0, 9),
             'heavy_license' => $newHeavyLicense,
             'heavy_license_type' => $newHeavyLicenseType,
-            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1,5))),
+            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1, 5))),
             'tcc' => $newChildrenTransportationCertified,
             'tcc_expiration_date' => $newCertificationExpiration,
-        ]; 
-        
+        ];
+
         $response = $this
             ->actingAs($this->user)
             ->put((route('drivers.edit', $driver->user_id)), $updatedData);
@@ -394,6 +460,66 @@ class DriverTest extends TestCase
             'tcc' => $updatedData['tcc'],
             'tcc_expiration_date' => $updatedData['tcc_expiration_date'],
         ]);
+    }
+
+    public function test_user_cannot_edit_a_driver_due_permissions(): void
+    {
+        $heavyLicense = rand(0, 1);
+        $heavyLicenseType = $heavyLicense ? Arr::random(['Mercadorias', 'Passageiros']) : null;
+        $childrenTransportationCertified = rand(0, 1);
+        $certificationExpiration = $childrenTransportationCertified ? fake()->date() : null;
+
+        $driverUser = Driver::factory()->create([
+            'user_id' => User::factory()->create()->id,
+            'heavy_license' => $heavyLicense,
+            'heavy_license_type' => $heavyLicenseType,
+            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1, 5))),
+            'tcc' => $childrenTransportationCertified,
+            'tcc_expiration_date' => $certificationExpiration,
+        ]);
+
+        $newHeavyLicense = rand(0, 1);
+        $newHeavyLicenseType = $newHeavyLicense ? Arr::random(['Mercadorias', 'Passageiros']) : null;
+        $newChildrenTransportationCertified = rand(0, 1);
+        $newCertificationExpiration = $newChildrenTransportationCertified ? fake()->date() : null;
+
+        $updatedData = [
+            'user_id' => $driverUser->user_id,
+            'name' => $driverUser->name,
+            'email' => $driverUser->email,
+            'phone' => $driverUser->phone,
+            'status' => Arr::random(['Disponível', 'Indisponível', 'Em Serviço', 'Escondido']),
+            'license_number' => $this->getRandomRegionIdentifier() . '-' . str_pad(rand(0, 999999), 6, '0', STR_PAD_LEFT) . ' ' . rand(0, 9),
+            'heavy_license' => $newHeavyLicense,
+            'heavy_license_type' => $newHeavyLicenseType,
+            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1, 5))),
+            'tcc' => $newChildrenTransportationCertified,
+            'tcc_expiration_date' => $newCertificationExpiration,
+        ];
+
+        $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
+
+        $users = [$technician, $driver, $none];
+
+        foreach ($users as $user) {
+            $response = $this
+                ->actingAs($user)
+                ->put(route('drivers.edit', $driverUser->user_id), $updatedData);
+
+            $response->assertForbidden();
+
+            $this->assertDatabaseMissing('drivers', [
+                'user_id' => $driverUser->user_id,
+                'license_number' => $updatedData['license_number'],
+                'heavy_license' => $newHeavyLicense,
+                'heavy_license_type' => $newHeavyLicenseType,
+                'license_expiration_date' => $updatedData['license_expiration_date'],
+                'tcc' => $updatedData['tcc'],
+                'tcc_expiration_date' => $updatedData['tcc_expiration_date'],
+            ]);
+        }
     }
 
     public function test_user_can_delete_a_driver(): void
@@ -415,13 +541,38 @@ class DriverTest extends TestCase
         ]);
     }
 
+    public function test_user_cannot_delete_a_driver_due_permissions(): void
+    {
+        $driverToDelete = Driver::factory()->create([
+            'user_id' => User::factory()->create()->id,
+        ]);
+
+        $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
+
+        $users = [$technician, $driver, $none];
+
+        foreach ($users as $user) {
+            $response = $this
+                ->actingAs($user)
+                ->delete(route('drivers.delete', $driverToDelete->user_id));
+
+            $response->assertForbidden();
+
+            $this->assertDatabaseHas('drivers', [
+                'user_id' => $driverToDelete->user_id,
+            ]);
+        }
+    }
+
     public function test_driver_creation_handles_exception()
     {
         $data = [
             'user_id' => User::factory()->create()->id,
             'license_number' => $this->getRandomRegionIdentifier() . '-' . str_pad(rand(0, 999999), 6, '0', STR_PAD_LEFT) . ' ' . rand(0, 9),
             'heavy_license' => 0,
-            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1,5))),
+            'license_expiration_date' => fake()->date('Y-m-d', now()->addYears(rand(1, 5))),
             'tcc' => 0,
         ];
 
@@ -438,5 +589,28 @@ class DriverTest extends TestCase
 
         // Assert: Check if the catch block was executed
         $response->assertRedirect(route('drivers.index')); // Ensure it redirects back to the form
+    }
+
+    /**
+     * Auxiliar method to verify if non-admin users cannot access some pages
+     * @param string $route
+     * @param mixed $id
+     * @return void
+     */
+    private function assertForbiddenForNonAdminsAndManagers(string $route, ?int $id = null): void
+    {
+        $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
+
+        $users = [$technician, $driver, $none];
+
+        foreach ($users as $user) {
+            $response = $this
+                ->actingAs($user)
+                ->get(route($route, $id ? [$id] : []));
+
+            $response->assertForbidden();
+        }
     }
 }

--- a/laravel/tests/Feature/Users/ManagerTest.php
+++ b/laravel/tests/Feature/Users/ManagerTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature;
 
+use App\Enums\Roles;
+use Database\Factories\UserFactory;
 use Tests\TestCase;
 use App\Models\User;
 use Illuminate\Support\Arr;
@@ -18,7 +20,7 @@ class ManagerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create(['user_type' => 'Administrador']);
+        $this->user = User::factory()->create(['user_type' => Roles::ADMIN->value]);
     }
 
     public function test_managers_page_is_displayed(): void
@@ -30,6 +32,11 @@ class ManagerTest extends TestCase
         $response->assertOk();
     }
 
+    public function test_managers_page_is_not_displayed_due_permissions(): void
+    {
+        $this->assertForbiddenForNonAdmins('managers.index', null, true);
+    }
+
     public function test_manager_creation_page_is_displayed(): void
     {
         $response = $this
@@ -37,6 +44,11 @@ class ManagerTest extends TestCase
             ->get(route('managers.showCreate'));
 
         $response->assertOk();
+    }
+
+    public function test_manager_creation_page_is_not_displayed_due_permissions(): void
+    {
+        $this->assertForbiddenForNonAdmins('managers.showCreate');
     }
 
     public function test_manager_edit_page_is_displayed(): void
@@ -50,6 +62,13 @@ class ManagerTest extends TestCase
         $response->assertOk();
     }
 
+    public function test_manager_edit_page_is_not_displayed_due_permissions(): void
+    {
+        $manager = ManagerFactory::new()->create();
+
+        $this->assertForbiddenForNonAdmins('managers.showEdit', $manager->id, true);
+    }
+
     public function test_manager_approved_orders_page_is_displayed(): void
     {
         $manager = ManagerFactory::new()->create();
@@ -59,6 +78,13 @@ class ManagerTest extends TestCase
             ->get(route('managers.approved', $manager->id));
 
         $response->assertOk();
+    }
+
+    public function test_manager_approved_orders_page_is_not_displayed_due_permissions(): void
+    {
+        $manager = ManagerFactory::new()->create();
+
+        $this->assertForbiddenForNonAdmins('managers.approved', $manager->id, true);
     }
 
     public function test_user_can_create_a_manager(): void
@@ -81,10 +107,40 @@ class ManagerTest extends TestCase
         $this->assertDatabaseHas('users', $managerData);
     }
 
+    public function test_user_cannot_create_a_manager_due_permissions(): void
+    {
+        $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
+        $manager = UserFactory::new()->create(['user_type' => Roles::MANAGER->value]);
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
+
+        $users = [$technician, $manager, $driver, $none];
+
+        foreach ($users as $user) {
+            $newManager = User::factory()->create();
+
+            $managerData = [
+                'id' => $newManager->id,
+                'user_type' => Roles::NONE->value
+            ];
+
+            $response = $this
+                ->actingAs($user)
+                ->post(route('managers.create'), $managerData);
+
+            $response->assertForbidden();
+
+            $this->assertDatabaseMissing('users', [
+                'id' => $newManager->id,
+                'user_type' => Roles::MANAGER->value,
+            ]);
+        }
+    }
+
     public function test_create_manager_fails_on_user_type_is_not_none(): void
     {
         $user = User::factory()->create([
-            'user_type' => Arr::random(['Técnico', 'Condutor', 'Administrador']),
+            'user_type' => Arr::random([Roles::TECHNICIAN->value, Roles::DRIVER->value, Roles::ADMIN->value]),
         ]);
 
         $managerData = [
@@ -99,21 +155,21 @@ class ManagerTest extends TestCase
 
         $this->assertDatabaseMissing('users', [
             'id' => $user->id,
-            'user_type' => 'Gestor',
+            'user_type' => Roles::MANAGER->value,
         ]);
     }
 
     public function test_user_can_edit_a_manager(): void
     {
         $manager = ManagerFactory::new()->create();
-    
+
         $updatedData = [
             'name' => fake()->name(),
             'phone' => rand(910000000, 999999999),
             'email' => fake()->unique()->safeEmail(),
             'status' => Arr::random(['Disponível', 'Indisponível', 'Em Serviço', 'Escondido']),
-        ]; 
-        
+        ];
+
         $response = $this
             ->actingAs($this->user)
             ->put(route('managers.edit', $manager->id), $updatedData);
@@ -125,13 +181,41 @@ class ManagerTest extends TestCase
         $this->assertDatabaseHas('users', $updatedData);
     }
 
+    public function test_user_cannot_edit_a_manager_due_permissions(): void
+    {
+        $manager = ManagerFactory::new()->create();
+
+        $updatedData = [
+            'name' => fake()->name(),
+            'phone' => rand(910000000, 999999999),
+            'email' => fake()->unique()->safeEmail(),
+            'status' => Arr::random(['Disponível', 'Indisponível', 'Em Serviço', 'Escondido']),
+        ];
+
+        $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
+
+        $users = [$technician, $driver, $none];
+
+        foreach ($users as $user) {
+            $response = $this
+                ->actingAs($user)
+                ->put(route('managers.edit', $manager->id), $updatedData);
+
+            $response->assertForbidden();
+
+            $this->assertDatabaseMissing('users', $updatedData);
+        }
+    }
+
     public function test_user_can_delete_a_manager(): void
     {
         $manager = ManagerFactory::new()->create();
 
         $this->assertDatabaseHas('users', [
             'id' => $manager->id,
-            'user_type' => 'Gestor'
+            'user_type' => Roles::MANAGER->value
         ]);
 
         $response = $this
@@ -146,6 +230,41 @@ class ManagerTest extends TestCase
             'id' => $manager->id,
             'user_type' => 'Nenhum'
         ]);
+    }
+
+    public function test_user_cannot_delete_a_manager_due_permissions(): void
+    {
+        $manager = ManagerFactory::new()->create();
+
+        $this->assertDatabaseHas('users', [
+            'id' => $manager->id,
+            'user_type' => Roles::MANAGER->value
+        ]);
+
+        $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
+        $manager = UserFactory::new()->create(['user_type' => Roles::MANAGER->value]);
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
+
+        $users = [$technician, $manager, $driver, $none];
+
+        foreach ($users as $user) {
+            $response = $this
+                ->actingAs($user)
+                ->delete(route('admins.delete', $manager->id));
+
+            $response->assertForbidden();
+
+            $this->assertDatabaseMissing('users', [
+                'id' => $manager->id,
+                'user_type' => Roles::NONE->value
+            ]);
+
+            $this->assertDatabaseHas('users', [
+                'id' => $manager->id,
+                'user_type' => Roles::MANAGER->value
+            ]);
+        }
     }
 
     public function test_manager_creation_handles_exception()
@@ -169,6 +288,35 @@ class ManagerTest extends TestCase
 
         // Assert: Check if the catch block was executed
         $response->assertRedirect(route('managers.index')); // Ensure it redirects back to the form
+    }
+
+    /**
+     * Auxiliar method to verify if non-admin users cannot access some pages
+     * @param string $route
+     * @param mixed $id
+     * @param bool $managerCanView
+     * @return void
+     */
+    private function assertForbiddenForNonAdmins(string $route, ?int $id = null, ?bool $managerCanView = false): void
+    {
+        $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
+        $manager = UserFactory::new()->create(['user_type' => Roles::MANAGER->value]);
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
+
+        $users = [$technician, $driver, $none];
+
+        if (!$managerCanView) {
+            array_push($users, $manager);
+        }
+
+        foreach ($users as $user) {
+            $response = $this
+                ->actingAs($user)
+                ->get(route($route, $id ? [$id] : []));
+
+            $response->assertForbidden();
+        }
     }
 
 }

--- a/laravel/tests/Feature/Users/TechnicianTest.php
+++ b/laravel/tests/Feature/Users/TechnicianTest.php
@@ -266,10 +266,11 @@ class TechnicianTest extends TestCase
      */
     private function assertForbiddenForUnauthorizedUsers(string $route, ?int $id = null): void
     {
+        $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
         $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
         $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
 
-        $users = [$driver, $none];
+        $users = [$technician, $driver, $none];
 
         foreach ($users as $user) {
             $response = $this

--- a/laravel/tests/Feature/Users/TechnicianTest.php
+++ b/laravel/tests/Feature/Users/TechnicianTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Enums\Roles;
 use App\Models\Kid;
+use Database\Factories\UserFactory;
 use Tests\TestCase;
 use App\Models\User;
 use Illuminate\Support\Arr;
@@ -31,6 +33,11 @@ class TechnicianTest extends TestCase
         $response->assertOk();
     }
 
+    public function test_technicians_page_is_not_displayed_due_permissions(): void
+    {
+        $this->assertForbiddenForUnauthorizedUsers('technicians.index');
+    }
+
     public function test_technician_creation_page_is_displayed(): void
     {
         $response = $this
@@ -38,6 +45,11 @@ class TechnicianTest extends TestCase
             ->get(route('technicians.showCreate'));
 
         $response->assertOk();
+    }
+
+    public function test_technician_creation_page_is_not_displayed_due_permissions(): void
+    {
+        $this->assertForbiddenForUnauthorizedUsers('technicians.showCreate');
     }
 
     public function test_technician_edit_page_is_displayed(): void
@@ -49,6 +61,13 @@ class TechnicianTest extends TestCase
             ->get(route('technicians.showEdit', $technician->id));
 
         $response->assertOk();
+    }
+
+    public function test_technician_edit_page_is_not_displayed_due_permissions(): void
+    {
+        $technician = TechnicianFactory::new()->create();
+
+        $this->assertForbiddenForUnauthorizedUsers('technicians.showEdit', $technician->id);
     }
 
     public function test_user_can_create_a_technician(): void
@@ -71,10 +90,38 @@ class TechnicianTest extends TestCase
         $this->assertDatabaseHas('users', $technicianData);
     }
 
+    public function test_user_cannot_create_a_technician_due_permissions(): void
+    {
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
+
+        $users = [$driver, $none];
+
+        foreach ($users as $user) {
+            $newTechnician = User::factory()->create();
+
+            $technicianData = [
+                'id' => $newTechnician->id,
+                'user_type' => Roles::NONE->value
+            ];
+
+            $response = $this
+                ->actingAs($user)
+                ->post(route('technicians.create'), $technicianData);
+
+            $response->assertForbidden();
+
+            $this->assertDatabaseMissing('users', [
+                'id' => $user->id,
+                'user_type' => Roles::TECHNICIAN->value,
+            ]);
+        }
+    }
+
     public function test_create_technician_fails_on_user_type_is_not_none(): void
     {
         $user = User::factory()->create([
-            'user_type' => 'Gestor',
+            'user_type' => Roles::MANAGER->value,
         ]);
 
         $technicianData = [
@@ -96,14 +143,14 @@ class TechnicianTest extends TestCase
     public function test_user_can_edit_a_technician(): void
     {
         $technician = TechnicianFactory::new()->create();
-    
+
         $updatedData = [
             'name' => fake()->name(),
             'phone' => rand(910000000, 999999999),
             'email' => fake()->unique()->safeEmail(),
             'status' => Arr::random(['Disponível', 'Indisponível', 'Em Serviço', 'Escondido']),
-        ]; 
-        
+        ];
+
         $response = $this
             ->actingAs($this->user)
             ->put(route('technicians.edit', $technician->id), $updatedData);
@@ -113,6 +160,33 @@ class TechnicianTest extends TestCase
             ->assertRedirect(route('technicians.index'));
 
         $this->assertDatabaseHas('users', $updatedData);
+    }
+
+    public function test_user_cannot_edit_a_technician_due_permissions(): void
+    {
+        $technician = TechnicianFactory::new()->create();
+
+        $updatedData = [
+            'name' => fake()->name(),
+            'phone' => rand(910000000, 999999999),
+            'email' => fake()->unique()->safeEmail(),
+            'status' => Arr::random(['Disponível', 'Indisponível', 'Em Serviço', 'Escondido']),
+        ];
+
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
+
+        $users = [$driver, $none];
+
+        foreach ($users as $user) {
+            $response = $this
+                ->actingAs($user)
+                ->put(route('technicians.edit', $technician->id), $updatedData);
+
+            $response->assertForbidden();
+
+            $this->assertDatabaseMissing('users', $updatedData);
+        }
     }
 
     public function test_user_can_delete_a_technician(): void
@@ -134,8 +208,31 @@ class TechnicianTest extends TestCase
 
         $this->assertDatabaseHas('users', [
             'id' => $technician->id,
-            'user_type' => 'Nenhum'
+            'user_type' => Roles::NONE->value
         ]);
+    }
+
+    public function test_user_cannot_delete_a_technician_due_permissions(): void
+    {
+        $technician = TechnicianFactory::new()->create();
+
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
+
+        $users = [$driver, $none];
+
+        foreach ($users as $user) {
+            $response = $this
+                ->actingAs($user)
+                ->delete(route('technicians.delete', $technician->id));
+
+            $response->assertForbidden();
+
+            $this->assertDatabaseMissing('users', [
+                'id' => $technician->id,
+                'user_type' => Roles::NONE->value
+            ]);
+        }
     }
 
     public function test_technician_creation_handles_exception()
@@ -159,6 +256,28 @@ class TechnicianTest extends TestCase
 
         // Assert: Check if the catch block was executed
         $response->assertRedirect(route('technicians.index')); // Ensure it redirects back to the form
+    }
+
+    /**
+     * Auxiliar method to verify if driver and none users cannot access some pages
+     * @param string $route
+     * @param mixed $id
+     * @return void
+     */
+    private function assertForbiddenForUnauthorizedUsers(string $route, ?int $id = null): void
+    {
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
+
+        $users = [$driver, $none];
+
+        foreach ($users as $user) {
+            $response = $this
+                ->actingAs($user)
+                ->get(route($route, $id ? [$id] : []));
+
+            $response->assertForbidden();
+        }
     }
 
 }

--- a/laravel/tests/Feature/Users/TechnicianTest.php
+++ b/laravel/tests/Feature/Users/TechnicianTest.php
@@ -21,7 +21,7 @@ class TechnicianTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create(['user_type' => 'Administrador']);
+        $this->user = User::factory()->create(['user_type' => Roles::ADMIN->value]);
     }
 
     public function test_technicians_page_is_displayed(): void
@@ -136,7 +136,7 @@ class TechnicianTest extends TestCase
 
         $this->assertDatabaseMissing('users', [
             'id' => $user->id,
-            'user_type' => 'Técnico',
+            'user_type' => Roles::TECHNICIAN->value,
         ]);
     }
 
@@ -195,7 +195,7 @@ class TechnicianTest extends TestCase
 
         $this->assertDatabaseHas('users', [
             'id' => $technician->id,
-            'user_type' => 'Técnico'
+            'user_type' => Roles::TECHNICIAN->value
         ]);
 
         $response = $this

--- a/laravel/tests/Feature/Users/UserTest.php
+++ b/laravel/tests/Feature/Users/UserTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature;
 
+use App\Enums\Roles;
+use Database\Factories\UserFactory;
 use Tests\TestCase;
 use App\Models\User;
 use App\Models\Order;
@@ -23,7 +25,7 @@ class UserTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create(['user_type' => 'Administrador']);
+        $this->user = User::factory()->create(['user_type' => Roles::ADMIN->value]);
     }
 
     public function test_user_has_one_driver(): void
@@ -38,7 +40,7 @@ class UserTest extends TestCase
     public function test_user_has_many_orders_as_technician(): void
     {
         $technician = User::factory()->create([
-            'user_type' => 'Técnico',
+            'user_type' => Roles::TECHNICIAN->value,
         ]);
 
         $orders = Order::factory()->count(3)->create([
@@ -55,7 +57,7 @@ class UserTest extends TestCase
     public function test_user_has_many_orders_as_manager(): void
     {
         $manager = User::factory()->create([
-            'user_type' => 'Gestor',
+            'user_type' => Roles::MANAGER->value,
         ]);
 
         $orders = Order::factory()->count(3)->create([
@@ -128,6 +130,11 @@ class UserTest extends TestCase
         $response->assertOk();
     }
 
+    public function test_users_page_is_not_displayed_due_permissions(): void
+    {
+        $this->assertForbiddenForUnauthorizedUsers('users.index');
+    }
+
     public function test_user_creation_page_is_displayed(): void
     {
         $response = $this
@@ -135,6 +142,11 @@ class UserTest extends TestCase
             ->get(route('users.showCreate'));
 
         $response->assertOk();
+    }
+
+    public function test_user_creation_page_is_not_displayed_due_permissions(): void
+    {
+        $this->assertForbiddenForUnauthorizedUsers('users.showCreate');
     }
 
     public function test_user_edit_page_is_displayed(): void
@@ -148,13 +160,20 @@ class UserTest extends TestCase
         $response->assertOk();
     }
 
+    public function test_user_edit_page_is_not_displayed_due_permissions(): void
+    {
+        $user = User::factory()->create();
+
+        $this->assertForbiddenForUnauthorizedUsers('users.showEdit', $user->id);
+    }
+
     public function test_user_can_create_another_user(): void
     {
 
         $userData = [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
-            'password' =>  'Teste1234*',
+            'password' => 'Teste1234*',
             'password_confirmation' => 'Teste1234*',
             'phone' => '' . rand(910000000, 999999999),
         ];
@@ -172,6 +191,37 @@ class UserTest extends TestCase
             'email' => $userData['email'],
             'phone' => $userData['phone'],
         ]);
+    }
+
+    public function test_user_cannnot_create_another_user_due_permissions(): void
+    {
+        $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
+
+        $users = [$technician, $driver, $none];
+
+        foreach ($users as $user) {
+            $userData = [
+                'name' => fake()->name(),
+                'email' => fake()->unique()->safeEmail(),
+                'password' => 'Teste1234*',
+                'password_confirmation' => 'Teste1234*',
+                'phone' => '' . rand(910000000, 999999999),
+            ];
+
+            $response = $this
+                ->actingAs($user)
+                ->post(route('users.create'), $userData);
+
+            $response->assertForbidden();
+
+            $this->assertDatabaseMissing('users', [
+                'name' => $userData['name'],
+                'email' => $userData['email'],
+                'phone' => $userData['phone'],
+            ]);
+        }
     }
 
     public function test_user_can_edit_another_user(): void
@@ -196,6 +246,34 @@ class UserTest extends TestCase
         $this->assertDatabaseHas('users', $updatedData);
     }
 
+    public function test_user_cannot_edit_another_user_due_permissions(): void
+    {
+        $user = User::factory()->create();
+
+        $updatedData = [
+            'name' => fake()->name(),
+            'email' => fake()->unique()->safeEmail(),
+            'phone' => rand(910000000, 999999999),
+            'status' => Arr::random(['Disponível', 'Indisponível', 'Em Serviço', 'Escondido']),
+        ];
+
+        $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
+
+        $users = [$technician, $driver, $none];
+
+        foreach ($users as $user) {
+            $response = $this
+                ->actingAs($user)
+                ->put(route('users.edit', $user->id), $updatedData);
+
+            $response->assertForbidden();
+
+            $this->assertDatabaseMissing('users', $updatedData);
+        }
+    }
+
     public function test_user_can_delete_another_user(): void
     {
         $user = User::factory()->create();
@@ -213,12 +291,39 @@ class UserTest extends TestCase
         ]);
     }
 
+    public function test_user_cannot_delete_another_user_due_permissions(): void
+    {
+        $user = User::factory()->create();
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+        ]);
+
+        $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
+
+        $users = [$technician, $driver, $none];
+
+        foreach ($users as $user) {
+            $response = $this
+                ->actingAs($user)
+                ->delete(route('users.delete', $user->id));
+
+            $response->assertForbidden();
+
+            $this->assertDatabaseHas('users', [
+                'id' => $user->id,
+            ]);
+        }
+    }
+
     public function test_user_creation_handles_exception()
     {
         $data = [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
-            'password' =>  'Teste1234*',
+            'password' => 'Teste1234*',
             'password_confirmation' => 'Teste1234*',
             'phone' => '' . rand(910000000, 999999999),
         ];
@@ -236,5 +341,28 @@ class UserTest extends TestCase
 
         // Assert: Check if the catch block was executed
         $response->assertRedirect(route('users.index')); // Ensure it redirects back to the form
+    }
+
+    /**
+     * Auxiliar method to verify if driver and none users cannot access some pages
+     * @param string $route
+     * @param mixed $id
+     * @return void
+     */
+    private function assertForbiddenForUnauthorizedUsers(string $route, ?int $id = null): void
+    {
+        $technician = UserFactory::new()->create(['user_type' => Roles::TECHNICIAN->value]);
+        $driver = UserFactory::new()->create(['user_type' => Roles::DRIVER->value]);
+        $none = UserFactory::new()->create(['user_type' => Roles::NONE->value]);
+
+        $users = [$technician, $driver, $none];
+
+        foreach ($users as $user) {
+            $response = $this
+                ->actingAs($user)
+                ->get(route($route, $id ? [$id] : []));
+
+            $response->assertForbidden();
+        }
     }
 }


### PR DESCRIPTION
## **Description**  

This PR introduces an **Admin section**, similar to those for Managers, Technicians, and Drivers. It also includes **permission tests** to ensure proper access control.  

## **Changes**  

### **Admin Pages**  
- Added **All Admins** page  
- Added **New Admin** page  
- Added **Edit Admin** page  
- Created **AdminController** and **AdminFactory**  

### **Tests & Permissions**  
- Added tests for **AdminController** methods, routes, and page access  
- Updated **TechnicianTests**: Only **Admins** and **Managers** can access Technician-related pages  
- Updated **ManagerTests**: Only **Admins** can access Manager-related pages  
- Updated **DriverTests**: Only **Admins** and **Managers** can access Driver-related pages  
- Updated **UserTests**: Only **Admins** and **Managers** can access User-related pages  
